### PR TITLE
Include vaadin-chart-default-theme in shared-styles

### DIFF
--- a/demo/src/main/webapp/frontend/src/shared-styles.html
+++ b/demo/src/main/webapp/frontend/src/shared-styles.html
@@ -9,11 +9,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../bower_components/vaadin-charts/vaadin-chart-default-theme.html">
 
 <!-- shared styles for all views -->
 <dom-module id="shared-styles" theme-for="vaadin-chart">
   <template>
-    <style>
+    <style include="vaadin-chart-default-theme">
       :host(.columnlineandpie) g.highcharts-markers > .highcharts-point {
         fill: white;
       }


### PR DESCRIPTION
Prevents `shared-styles` from [hiding](https://github.com/vaadin/vaadin-themable-mixin/commit/d6bb7cc0067fcacab132d65556e25903a0513098#diff-6f3dfb44506aa47806b92c7ded169272R38) `vaadin-chart-default-theme` which fixes the broken demo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts-flow/64)
<!-- Reviewable:end -->
