### PR TITLE
Remove shared-styles include from demo-area style

### DIFF
--- a/demo/src/main/webapp/frontend/src/demo-area.html
+++ b/demo/src/main/webapp/frontend/src/demo-area.html
@@ -7,7 +7,7 @@
 
 <dom-module id="demo-area">
   <template>
-    <style include="shared-styles">
+    <style>
        :host {
         height: 100%;
         width: 100%;


### PR DESCRIPTION
`vaadin-charts` uses a theme loader, which copies a custom theme into the component if one is found.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts-flow/104)
<!-- Reviewable:end -->
