### PR TITLE
Don't depend on transitive dependency

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -55,6 +55,11 @@
             <artifactId>fast-classpath-scanner</artifactId>
             <version>2.12.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.5</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
StringUtils, ImmutablePair and Pair classes are used from `commons-lang3` 
which was resolved from `webjars-locator-core` 
which `vaadin-server` could drop at any time

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts-flow/117)
<!-- Reviewable:end -->
