### PR TITLE
Fix file and style module name typo

### DIFF
--- a/examples/src/main/java/com/vaadin/flow/component/charts/examples/other/GaugeWithDualAxes.html
+++ b/examples/src/main/java/com/vaadin/flow/component/charts/examples/other/GaugeWithDualAxes.html
@@ -1,4 +1,4 @@
-<dom-module id="GuageWithDualAxes" theme-for="vaadin-chart">
+<dom-module id="GaugeWithDualAxes" theme-for="vaadin-chart">
   <template>
     <style>
       :host(.GaugeWithDualAxes) .kmh .highcharts-minor-tick {


### PR DESCRIPTION
This was preventing "Style" tab to show on demo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts-flow/158)
<!-- Reviewable:end -->
