### PR TITLE
Use fixed version of webcomponentsjs

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -58,6 +58,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.webcomponents</groupId>
+            <artifactId>webcomponentsjs</artifactId>
+            <version>1.2.0</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Incorrect range in polymer webjar resolves to webcomponentsjs 2.0.0.beta2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts-flow/165)
<!-- Reviewable:end -->
