### PR TITLE
Add negativeColor to PlotOptions* classes

### DIFF
--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/AreaOptions.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/AreaOptions.java
@@ -252,14 +252,17 @@ public abstract class AreaOptions extends AbstractPlotOptions {
     public abstract void setLinkedTo(String linkedTo);
 
     /**
-     * @see #setNegativeFillColor(boolean)
+     * @see #setNegativeColor(boolean)
      */
-    public abstract boolean isNegativeFillColor();
+    public abstract boolean isNegativeColor();
 
     /**
-     * A separate color for the negative part of the area.
+     * Enable or disable the color for parts of the graph that are bellow
+     * <code>threshold</code>. A negative color is applied by setting this
+     * option to <code>true</code> combined with the
+     * <code>.highcharts-negative</code> class name.
      */
-    public abstract void setNegativeFillColor(boolean negativeFillColor);
+    public abstract void setNegativeColor(boolean negativeColor);
 
     public abstract String getPointDescriptionFormatter();
 

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArea.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArea.java
@@ -47,7 +47,6 @@ public class PlotOptionsArea extends AreaOptions {
 	private String linkedTo;
 	private Marker marker;
 	private boolean negativeColor;
-	private boolean negativeFillColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -505,22 +504,6 @@ public class PlotOptionsArea extends AreaOptions {
 	 */
 	public void setNegativeColor(boolean negativeColor) {
 		this.negativeColor = negativeColor;
-	}
-
-	/**
-	 * @see #setNegativeFillColor(boolean)
-	 */
-	public boolean isNegativeFillColor() {
-		return negativeFillColor;
-	}
-
-	/**
-	 * Enable or disable the color for parts of the area.
-	 * 
-	 * @see #setNegativeColor(Boolean)
-	 */
-	public void setNegativeFillColor(boolean negativeFillColor) {
-		this.negativeFillColor = negativeFillColor;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArea.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArea.java
@@ -46,6 +46,7 @@ public class PlotOptionsArea extends AreaOptions {
 	private String linecap;
 	private String linkedTo;
 	private Marker marker;
+	private boolean negativeColor;
 	private boolean negativeFillColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
@@ -490,6 +491,23 @@ public class PlotOptionsArea extends AreaOptions {
 	}
 
 	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
+	}
+
+	/**
 	 * @see #setNegativeFillColor(boolean)
 	 */
 	public boolean isNegativeFillColor() {
@@ -497,7 +515,9 @@ public class PlotOptionsArea extends AreaOptions {
 	}
 
 	/**
-	 * A separate color for the negative part of the area.
+	 * Enable or disable the color for parts of the area.
+	 * 
+	 * @see #setNegativeColor(Boolean)
 	 */
 	public void setNegativeFillColor(boolean negativeFillColor) {
 		this.negativeFillColor = negativeFillColor;

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArearange.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArearange.java
@@ -49,7 +49,6 @@ public class PlotOptionsArearange extends AreaOptions {
 	private String linecap;
 	private String linkedTo;
 	private boolean negativeColor;
-	private boolean negativeFillColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -450,22 +449,6 @@ public class PlotOptionsArearange extends AreaOptions {
 	 */
 	public void setNegativeColor(boolean negativeColor) {
 		this.negativeColor = negativeColor;
-	}
-
-	/**
-	 * @see #setNegativeFillColor(boolean)
-	 */
-	public boolean isNegativeFillColor() {
-		return negativeFillColor;
-	}
-
-	/**
-	 * Enable or disable the color for parts of the area.
-	 * 
-	 * @see #setNegativeColor(Boolean)
-	 */
-	public void setNegativeFillColor(boolean negativeFillColor) {
-		this.negativeFillColor = negativeFillColor;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArearange.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArearange.java
@@ -48,6 +48,7 @@ public class PlotOptionsArearange extends AreaOptions {
 	private ArrayList<String> keys;
 	private String linecap;
 	private String linkedTo;
+	private boolean negativeColor;
 	private boolean negativeFillColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
@@ -435,6 +436,23 @@ public class PlotOptionsArearange extends AreaOptions {
 	}
 
 	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
+	}
+
+	/**
 	 * @see #setNegativeFillColor(boolean)
 	 */
 	public boolean isNegativeFillColor() {
@@ -442,7 +460,9 @@ public class PlotOptionsArearange extends AreaOptions {
 	}
 
 	/**
-	 * A separate color for the negative part of the area.
+	 * Enable or disable the color for parts of the area.
+	 * 
+	 * @see #setNegativeColor(Boolean)
 	 */
 	public void setNegativeFillColor(boolean negativeFillColor) {
 		this.negativeFillColor = negativeFillColor;

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreaspline.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreaspline.java
@@ -46,6 +46,7 @@ public class PlotOptionsAreaspline extends AreaOptions {
 	private String linecap;
 	private String linkedTo;
 	private Marker marker;
+	private boolean negativeColor;
 	private boolean negativeFillColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
@@ -489,6 +490,23 @@ public class PlotOptionsAreaspline extends AreaOptions {
 	}
 
 	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
+	}
+
+	/**
 	 * @see #setNegativeFillColor(boolean)
 	 */
 	public boolean isNegativeFillColor() {
@@ -496,7 +514,9 @@ public class PlotOptionsAreaspline extends AreaOptions {
 	}
 
 	/**
-	 * A separate color for the negative part of the area.
+	 * Enable or disable the color for parts of the area.
+	 * 
+	 * @see #setNegativeColor(Boolean)
 	 */
 	public void setNegativeFillColor(boolean negativeFillColor) {
 		this.negativeFillColor = negativeFillColor;

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreaspline.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreaspline.java
@@ -47,7 +47,6 @@ public class PlotOptionsAreaspline extends AreaOptions {
 	private String linkedTo;
 	private Marker marker;
 	private boolean negativeColor;
-	private boolean negativeFillColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -504,22 +503,6 @@ public class PlotOptionsAreaspline extends AreaOptions {
 	 */
 	public void setNegativeColor(boolean negativeColor) {
 		this.negativeColor = negativeColor;
-	}
-
-	/**
-	 * @see #setNegativeFillColor(boolean)
-	 */
-	public boolean isNegativeFillColor() {
-		return negativeFillColor;
-	}
-
-	/**
-	 * Enable or disable the color for parts of the area.
-	 * 
-	 * @see #setNegativeColor(Boolean)
-	 */
-	public void setNegativeFillColor(boolean negativeFillColor) {
-		this.negativeFillColor = negativeFillColor;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreasplinerange.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreasplinerange.java
@@ -49,7 +49,6 @@ public class PlotOptionsAreasplinerange extends AreaOptions {
 	private String linecap;
 	private String linkedTo;
 	private boolean negativeColor;
-	private boolean negativeFillColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -448,22 +447,6 @@ public class PlotOptionsAreasplinerange extends AreaOptions {
 	 */
 	public void setNegativeColor(boolean negativeColor) {
 		this.negativeColor = negativeColor;
-	}
-
-	/**
-	 * @see #setNegativeFillColor(boolean)
-	 */
-	public boolean isNegativeFillColor() {
-		return negativeFillColor;
-	}
-
-	/**
-	 * Enable or disable the color for parts of the area.
-	 * 
-	 * @see #setNegativeColor(Boolean)
-	 */
-	public void setNegativeFillColor(boolean negativeFillColor) {
-		this.negativeFillColor = negativeFillColor;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreasplinerange.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreasplinerange.java
@@ -48,6 +48,7 @@ public class PlotOptionsAreasplinerange extends AreaOptions {
 	private ArrayList<String> keys;
 	private String linecap;
 	private String linkedTo;
+	private boolean negativeColor;
 	private boolean negativeFillColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
@@ -433,6 +434,23 @@ public class PlotOptionsAreasplinerange extends AreaOptions {
 	}
 
 	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
+	}
+
+	/**
 	 * @see #setNegativeFillColor(boolean)
 	 */
 	public boolean isNegativeFillColor() {
@@ -440,7 +458,9 @@ public class PlotOptionsAreasplinerange extends AreaOptions {
 	}
 
 	/**
-	 * A separate color for the negative part of the area.
+	 * Enable or disable the color for parts of the area.
+	 * 
+	 * @see #setNegativeColor(Boolean)
 	 */
 	public void setNegativeFillColor(boolean negativeFillColor) {
 		this.negativeFillColor = negativeFillColor;

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBar.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBar.java
@@ -52,6 +52,7 @@ public class PlotOptionsBar extends ColumnOptions {
 	private String linkedTo;
 	private Number maxPointWidth;
 	private Number minPointLength;
+	private boolean negativeColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -565,6 +566,23 @@ public class PlotOptionsBar extends ColumnOptions {
 	 */
 	public void setMinPointLength(Number minPointLength) {
 		this.minPointLength = minPointLength;
+	}
+
+	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBoxplot.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBoxplot.java
@@ -54,6 +54,7 @@ public class PlotOptionsBoxplot extends AbstractPlotOptions {
 	private String linkedTo;
 	private Number maxPointWidth;
 	private Number medianWidth;
+	private boolean negativeColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -492,6 +493,23 @@ public class PlotOptionsBoxplot extends AbstractPlotOptions {
 	 */
 	public void setMedianWidth(Number medianWidth) {
 		this.medianWidth = medianWidth;
+	}
+
+	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBubble.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBubble.java
@@ -52,6 +52,7 @@ public class PlotOptionsBubble extends AbstractPlotOptions {
 	private Marker marker;
 	private String maxSize;
 	private String minSize;
+	private boolean negativeColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -493,6 +494,23 @@ public class PlotOptionsBubble extends AbstractPlotOptions {
 	 */
 	public void setMinSize(String minSize) {
 		this.minSize = minSize;
+	}
+
+	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsCandlestick.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsCandlestick.java
@@ -53,6 +53,7 @@ public class PlotOptionsCandlestick extends OhlcOptions {
 	private Number maxPointWidth;
 	private Number minPointLength;
 	private PlotOptionsSeries navigatorOptions;
+	private boolean negativeColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -541,6 +542,23 @@ public class PlotOptionsCandlestick extends OhlcOptions {
 	 */
 	public void setNavigatorOptions(PlotOptionsSeries navigatorOptions) {
 		this.navigatorOptions = navigatorOptions;
+	}
+
+	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsColumn.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsColumn.java
@@ -52,6 +52,7 @@ public class PlotOptionsColumn extends ColumnOptions {
 	private String linkedTo;
 	private Number maxPointWidth;
 	private Number minPointLength;
+	private boolean negativeColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -587,6 +588,23 @@ public class PlotOptionsColumn extends ColumnOptions {
 	 */
 	public void setMinPointLength(Number minPointLength) {
 		this.minPointLength = minPointLength;
+	}
+
+	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsErrorbar.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsErrorbar.java
@@ -51,6 +51,7 @@ public class PlotOptionsErrorbar extends AbstractPlotOptions {
 	private ArrayList<String> keys;
 	private String linkedTo;
 	private Number maxPointWidth;
+	private boolean negativeColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -439,6 +440,23 @@ public class PlotOptionsErrorbar extends AbstractPlotOptions {
 	 */
 	public void setMaxPointWidth(Number maxPointWidth) {
 		this.maxPointWidth = maxPointWidth;
+	}
+
+	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsFlags.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsFlags.java
@@ -45,6 +45,7 @@ public class PlotOptionsFlags extends AbstractPlotOptions {
 	private String linkedTo;
 	private Number maxPointWidth;
 	private PlotOptionsSeries navigatorOptions;
+	private boolean negativeColor;
 	private String onKey;
 	private String onSeries;
 	private String _fn_pointDescriptionFormatter;
@@ -449,6 +450,23 @@ public class PlotOptionsFlags extends AbstractPlotOptions {
 	 */
 	public void setNavigatorOptions(PlotOptionsSeries navigatorOptions) {
 		this.navigatorOptions = navigatorOptions;
+	}
+
+	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
 	}
 
 	/**

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsGauge.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsGauge.java
@@ -42,6 +42,7 @@ public class PlotOptionsGauge extends GaugeOptions {
 	private Boolean getExtremesFromAll;
 	private ArrayList<String> keys;
 	private String linkedTo;
+	private boolean negativeColor;
 	private Number overshoot;
 	private Pivot pivot;
 	private String _fn_pointDescriptionFormatter;
@@ -358,6 +359,23 @@ public class PlotOptionsGauge extends GaugeOptions {
 	 */
 	public void setLinkedTo(String linkedTo) {
 		this.linkedTo = linkedTo;
+	}
+
+	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
 	}
 
 	/**

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsLine.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsLine.java
@@ -46,6 +46,7 @@ public class PlotOptionsLine extends PointOptions {
 	private String linecap;
 	private String linkedTo;
 	private Marker marker;
+	private boolean negativeColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -485,6 +486,23 @@ public class PlotOptionsLine extends PointOptions {
 	 */
 	public void setMarker(Marker marker) {
 		this.marker = marker;
+	}
+
+	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsOhlc.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsOhlc.java
@@ -56,6 +56,7 @@ public class PlotOptionsOhlc extends OhlcOptions {
 	private Number maxPointWidth;
 	private Number minPointLength;
 	private PlotOptionsSeries navigatorOptions;
+	private boolean negativeColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -584,6 +585,23 @@ public class PlotOptionsOhlc extends OhlcOptions {
 	 */
 	public void setNavigatorOptions(PlotOptionsSeries navigatorOptions) {
 		this.navigatorOptions = navigatorOptions;
+	}
+
+	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsPolygon.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsPolygon.java
@@ -48,6 +48,7 @@ public class PlotOptionsPolygon extends AbstractPlotOptions {
 	private ArrayList<String> keys;
 	private String linkedTo;
 	private Marker marker;
+	private boolean negativeColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -405,6 +406,23 @@ public class PlotOptionsPolygon extends AbstractPlotOptions {
 	 */
 	public void setMarker(Marker marker) {
 		this.marker = marker;
+	}
+
+	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsScatter.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsScatter.java
@@ -43,6 +43,7 @@ public class PlotOptionsScatter extends PointOptions {
 	private ArrayList<String> keys;
 	private String linkedTo;
 	private Marker marker;
+	private boolean negativeColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -431,6 +432,23 @@ public class PlotOptionsScatter extends PointOptions {
 	 */
 	public void setMarker(Marker marker) {
 		this.marker = marker;
+	}
+
+	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSeries.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSeries.java
@@ -51,6 +51,7 @@ public class PlotOptionsSeries extends AbstractPlotOptions {
 	private String linecap;
 	private String linkedTo;
 	private Marker marker;
+	private boolean negativeColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -485,6 +486,23 @@ public class PlotOptionsSeries extends AbstractPlotOptions {
 	 */
 	public void setMarker(Marker marker) {
 		this.marker = marker;
+	}
+
+	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSpline.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSpline.java
@@ -46,6 +46,7 @@ public class PlotOptionsSpline extends PointOptions {
 	private String linecap;
 	private String linkedTo;
 	private Marker marker;
+	private boolean negativeColor;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -484,6 +485,23 @@ public class PlotOptionsSpline extends PointOptions {
 	 */
 	public void setMarker(Marker marker) {
 		this.marker = marker;
+	}
+
+	/**
+	 * @see #setNegativeColor(boolean)
+	 */
+	public boolean isNegativeColor() {
+		return negativeColor;
+	}
+
+	/**
+	 * Enable or disable the color for parts of the graph that are bellow
+	 * {@link #getThreshold()}. A negative color is applied by setting this
+	 * option to <code>true</code> combined with the
+	 * <code>.highcharts-negative</code> class name.
+	 */
+	public void setNegativeColor(boolean negativeColor) {
+		this.negativeColor = negativeColor;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/examples/src/main/java/com/vaadin/flow/component/charts/examples/other/ColorThreshold.java
+++ b/examples/src/main/java/com/vaadin/flow/component/charts/examples/other/ColorThreshold.java
@@ -10,7 +10,7 @@ public class ColorThreshold extends AreaRange {
         PlotOptionsArearange plotOptions = new PlotOptionsArearange();
         // Make "value" below -5 displayed with another color. Default threshold value is 0
         plotOptions.setThreshold(-5);
-        plotOptions.setNegativeFillColor(true);
+        plotOptions.setNegativeColor(true);
         chart.getConfiguration().setPlotOptions(plotOptions);
     }
 


### PR DESCRIPTION
* Add `negativeColor` as `boolean`
* Add doc describing which CSS class name to be used combined with `negativeColor`
* Remove `negativeFillColor` property
  * In styled mode, the effect of setting `negativeColor` and `negativeFillColor` is the same, so there's no need to keep both properties for area types series.

Fixes #185

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts-flow/187)
<!-- Reviewable:end -->
