### PR TITLE
Have polymer dependencies of the same versions as in other Flow components.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,19 +96,6 @@
                 <artifactId>flow-server-production-mode</artifactId>
                 <version>${flow.version}</version>
             </dependency>
-
-            <!--PIN webcomponentsjs AS A WORKAROND FOR https://github.com/webjars/webjars/issues/1763-->
-            <dependency>
-                <groupId>org.webjars.bowergithub.webcomponents</groupId>
-                <artifactId>webcomponentsjs</artifactId>
-                <version>[1.0.0,1.999.999)</version>
-            </dependency>
-            <!--PIN shadycss to 1.2.1 as 1.3.0 causes a transpilation error-->
-            <dependency>
-                <groupId>org.webjars.bowergithub.webcomponents</groupId>
-                <artifactId>shadycss</artifactId>
-                <version>1.2.1</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Those versions are defined by the `flow-component-base` already, no need to duplicate the declaration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts-flow/230)
<!-- Reviewable:end -->
