### PR TITLE
Add accessibility to Configuration object

### DIFF
--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
@@ -43,6 +43,7 @@ import java.util.Map;
 public class Configuration extends AbstractConfigurationObject
         implements ChartConfiguration {
 
+    private Accessibility accessibility;
     private ChartModel chart;
     private Title title;
     private Subtitle subtitle;
@@ -70,6 +71,25 @@ public class Configuration extends AbstractConfigurationObject
 
     @JsonIgnore
     private final List<ConfigurationChangeListener> changeListeners = new ArrayList<>();
+
+    /**
+     * @see #setAccessibility(Accessibility)
+     */
+    public Accessibility getAccessibility() {
+        if (accessibility == null) {
+            setAccessibility(new Accessibility());
+        }
+        return accessibility;
+    }
+
+    /**
+     * Sets options for configuring accessibility for the chart.
+     * 
+     * @param accessibility
+     */
+    public void setAccessibility(Accessibility accessibility) {
+        this.accessibility = accessibility;
+    }
 
     /**
      * @see #setChart(ChartModel)

--- a/examples/src/main/java/com/vaadin/flow/component/charts/examples/pie/PieWithoutAccessibility.java
+++ b/examples/src/main/java/com/vaadin/flow/component/charts/examples/pie/PieWithoutAccessibility.java
@@ -1,0 +1,15 @@
+package com.vaadin.flow.component.charts.examples.pie;
+
+import com.vaadin.flow.component.charts.SkipFromDemo;
+import com.vaadin.flow.component.charts.model.Accessibility;
+
+@SkipFromDemo
+public class PieWithoutAccessibility extends PieWithLegend {
+
+    @Override
+    public void initDemo() {
+        super.initDemo();
+        chart.getConfiguration().setAccessibility(new Accessibility(false));
+    }
+
+}

--- a/integration-test/src/test/java/com/vaadin/flow/component/charts/tests/PieWithoutAccessibilityIT.java
+++ b/integration-test/src/test/java/com/vaadin/flow/component/charts/tests/PieWithoutAccessibilityIT.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * Vaadin Charts
+ * %%
+ * Copyright (C) 2014 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Add-On License 3.0
+ * (CVALv3).
+ *
+ * See the file licensing.txt distributed with this software for more
+ * information about licensing.
+ *
+ * You should have received a copy of the CVALv3 along with this program.
+ * If not, see <https://vaadin.com/license/cval-3>.
+ * #L%
+ */
+package com.vaadin.flow.component.charts.tests;
+
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+
+import com.vaadin.flow.component.charts.AbstractChartExample;
+import com.vaadin.flow.component.charts.examples.pie.PieWithoutAccessibility;
+import com.vaadin.flow.component.charts.testbench.ChartElement;
+
+public class PieWithoutAccessibilityIT extends AbstractTBTest {
+
+    @Override
+    protected Class<? extends AbstractChartExample> getTestView() {
+        return PieWithoutAccessibility.class;
+    }
+
+    @Test
+    public void setSize_showChart_DimentionsAreSet() {
+        ChartElement chart = getChartElement();
+        assertFalse("Accessibility should be disabled",
+                chart.getPropertyBoolean("configuration", "userOptions",
+                        "accessibility", "enabled"));
+        assertFalse(chart.$("title").exists());
+    }
+}


### PR DESCRIPTION
API for accessibility was properly generated initially in 6.0
But setter for it was missing making it impossible to disable
or configure
Fixes #270

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts-flow/271)
<!-- Reviewable:end -->
