### PR TITLE
Remove conflicting point format

### DIFF
--- a/examples/src/main/java/com/vaadin/flow/component/charts/examples/pie/PieWithLegend.java
+++ b/examples/src/main/java/com/vaadin/flow/component/charts/examples/pie/PieWithLegend.java
@@ -24,7 +24,6 @@ public class PieWithLegend extends AbstractChartExample {
 
         Tooltip tooltip = new Tooltip();
         tooltip.setValueDecimals(1);
-        tooltip.setPointFormat("{series.name}: <b>{point.percentage}%</b>");
         conf.setTooltip(tooltip);
 
         PlotOptionsPie plotOptions = new PlotOptionsPie();


### PR DESCRIPTION
Previously `.setPointFormat("{series.name}: <b>{point.percentage}%</b>");` was overriding the value decimals
Closes #292

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts-flow/291)
<!-- Reviewable:end -->
