### PR TITLE
Exclude demo when -Dverify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,17 @@
 
     <profiles>
         <profile>
+            <id>demo</id>
+            <activation>
+                <property>
+                    <name>!verify</name>
+                </property>
+            </activation>
+            <modules>
+                <module>demo</module>
+            </modules>
+        </profile>
+        <profile>
             <id>npm-it</id>
             <activation>
                 <property>


### PR DESCRIPTION
Fixes builds for 7.0. It is not necessary for master, since there the demo module is gone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-charts-flow/319)
<!-- Reviewable:end -->
