### PR TITLE
Force serialization of ChartModel in configuration

### DIFF
--- a/addon/src/main/java/com/vaadin/flow/component/charts/ChartOptions.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/ChartOptions.java
@@ -77,7 +77,7 @@ public class ChartOptions extends AbstractConfigurationObject {
      * @return the ChartOptions instance connected to the given UI
      */
     public static ChartOptions get(UI ui) {
-        Objects.requireNonNull(ui, "Given root items may not be null");
+        Objects.requireNonNull(ui, "Given UI may not be null");
 
         ChartOptions options = ComponentUtil.getData(ui, ChartOptions.class);
 

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Chart's configuration root object containing all the child objects that are
@@ -45,7 +46,7 @@ public class Configuration extends AbstractConfigurationObject
         implements ChartConfiguration {
 
     private Accessibility accessibility;
-    private ChartModel chart;
+    private ChartModel chart = new ChartModel();
     private Title title;
     private Subtitle subtitle;
     private AxisList<XAxis> xAxis;
@@ -108,8 +109,10 @@ public class Configuration extends AbstractConfigurationObject
      * options.
      * 
      * @param chart
+     *            ChartModel to set, not <code>null</code>
      */
     public void setChart(ChartModel chart) {
+        Objects.requireNonNull(chart, "Given ChartModel may not be null");
         this.chart = chart;
     }
 

--- a/addon/src/test/java/com/vaadin/flow/component/charts/ConfigurationJSONSerializationTest.java
+++ b/addon/src/test/java/com/vaadin/flow/component/charts/ConfigurationJSONSerializationTest.java
@@ -1,0 +1,108 @@
+package com.vaadin.flow.component.charts;
+
+import static com.vaadin.flow.component.charts.util.ChartSerialization.toJSON;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.vaadin.flow.component.charts.events.internal.AxisRescaledEvent;
+import com.vaadin.flow.component.charts.events.internal.ConfigurationChangeListener;
+import com.vaadin.flow.component.charts.events.internal.DataAddedEvent;
+import com.vaadin.flow.component.charts.events.internal.DataRemovedEvent;
+import com.vaadin.flow.component.charts.events.internal.DataUpdatedEvent;
+import com.vaadin.flow.component.charts.events.internal.ItemSlicedEvent;
+import com.vaadin.flow.component.charts.events.internal.SeriesAddedEvent;
+import com.vaadin.flow.component.charts.events.internal.SeriesChangedEvent;
+import com.vaadin.flow.component.charts.events.internal.SeriesStateEvent;
+import com.vaadin.flow.component.charts.model.Configuration;
+import com.vaadin.flow.component.charts.model.YAxis;
+
+/**
+ * Tests for the JSON serialization in {@link Configuration}
+ *
+ */
+public class ConfigurationJSONSerializationTest {
+
+    @Test
+    public void configurationJSONSerialization_configurationSerializedWithChangeListener_changeListenerNotSerialized() {
+        Configuration conf = new Configuration();
+        conf.addChangeListener(new ConfigurationChangeListener() {
+
+            @Override
+            public void dataAdded(DataAddedEvent event) {
+                // TODO Auto-generated method stub
+
+            }
+
+            @Override
+            public void dataRemoved(DataRemovedEvent event) {
+                // TODO Auto-generated method stub
+
+            }
+
+            @Override
+            public void dataUpdated(DataUpdatedEvent event) {
+                // TODO Auto-generated method stub
+
+            }
+
+            @Override
+            public void itemSliced(ItemSlicedEvent event) {
+                // TODO Auto-generated method stub
+
+            }
+
+            @Override
+            public void seriesStateChanged(SeriesStateEvent event) {
+                // TODO Auto-generated method stub
+
+            }
+
+            @Override
+            public void seriesAdded(SeriesAddedEvent event) {
+                // TODO Auto-generated method stub
+
+            }
+
+            @Override
+            public void seriesChanged(SeriesChangedEvent event) {
+                // TODO Auto-generated method stub
+
+            }
+
+            @Override
+            public void axisRescaled(AxisRescaledEvent event) {
+                // TODO Auto-generated method stub
+
+            }
+
+            @Override
+            public void resetZoom(boolean redraw, boolean animate) {
+                // TODO Auto-generated method stub
+
+            }
+        });
+        assertEquals(
+                "{\"chart\":{\"styledMode\":false},\"plotOptions\":{},\"series\":[],\"exporting\":{\"enabled\":false}}",
+                toJSON(conf));
+    }
+
+    @Test
+    public void configurationJSONSerialization_configurationSerializedWithYAxis_yAxisConfigurationNotSerialized() {
+        Configuration conf = new Configuration();
+        YAxis axis = new YAxis();
+        conf.addyAxis(axis);
+        assertEquals(
+                "{\"chart\":{\"styledMode\":false},\"yAxis\":{\"axisIndex\":0},\"plotOptions\":{},\"series\":[],\"exporting\":{\"enabled\":false}}",
+                toJSON(conf));
+    }
+
+    @Test
+    public void configurationJSONSerialization_configurationSerializedStyledMode_styledModeSerialized() {
+        Configuration conf = new Configuration();
+        conf.getChart().setStyledMode(true);
+        assertEquals(
+                "{\"chart\":{\"styledMode\":true},\"plotOptions\":{},\"series\":[],\"exporting\":{\"enabled\":false}}",
+                toJSON(conf));
+    }
+}


### PR DESCRIPTION
ChartModel in configuration is required so that styledMode is disabled by default.
Fixes #384