### PR TITLE
Add missing options to PlotOptions

### DIFF
--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/AreaOptions.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/AreaOptions.java
@@ -287,17 +287,6 @@ public abstract class AreaOptions extends AbstractPlotOptions {
     public abstract void setGetExtremesFromAll(Boolean getExtremesFromAll);
 
     /**
-     * @see #setIncludeInDataExport(Boolean)
-     */
-    public abstract Boolean getIncludeInDataExport();
-
-    /**
-     * When set to <code>false</code> will prevent the series data
-     * from being included in any form of data export.
-     */
-    public abstract void setIncludeInDataExport(Boolean includeInDataExport);
-
-    /**
      * @see #setKeys(String...)
      */
     public abstract String[] getKeys();

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/AreaOptions.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/AreaOptions.java
@@ -82,6 +82,17 @@ public abstract class AreaOptions extends AbstractPlotOptions {
     public abstract void setClassName(String className);
 
     /**
+     * @see #setClip(Boolean)
+     */
+    public abstract Boolean getClip();
+
+    /**
+     * Disable this option to allow series rendering
+     * in the whole plotting area.
+     */
+    public abstract void setClip(Boolean clip);
+
+    /**
      * @see #setColorIndex(Number)
      */
     public abstract Number getColorIndex();
@@ -94,6 +105,18 @@ public abstract class AreaOptions extends AbstractPlotOptions {
     public abstract void setColorIndex(Number colorIndex);
 
     /**
+     * @see #setColorKey(String)
+     */
+    public abstract String getColorKey();
+
+    /**
+     * Determines what data value should be used to calculate point color if <code>colorAxis</code> is used.
+     * Requires to set <code>min</code> and <code>max</code> if some custom point property is used
+     * or if approximation for data grouping is set to <code>'sum'</code>.
+     */
+    public abstract void setColorKey(String colorKey);
+
+    /**
      * @see #setConnectNulls(Boolean)
      */
     public abstract Boolean getConnectNulls();
@@ -102,6 +125,19 @@ public abstract class AreaOptions extends AbstractPlotOptions {
      * Whether to connect a graph line across null points.
      */
     public abstract void setConnectNulls(Boolean connectNulls);
+
+    /**
+     * @see #setCrisp(Boolean)
+     */
+    public abstract Boolean getCrisp();
+
+    /**
+     * When true, each point or column edge is rounded to its nearest pixel
+     * in order to render sharp on screen. In some cases, when there are a lot of densely packed columns,
+     * this leads to visible difference in column widths or distance between columns.
+     * In these cases, setting crisp to false may look better, even though each column is rendered blurry.
+     */
+    public abstract void setCrisp(Boolean crisp);
 
     /**
      * @see #setCropThreshold(Number)
@@ -251,6 +287,17 @@ public abstract class AreaOptions extends AbstractPlotOptions {
     public abstract void setGetExtremesFromAll(Boolean getExtremesFromAll);
 
     /**
+     * @see #setIncludeInDataExport(Boolean)
+     */
+    public abstract Boolean getIncludeInDataExport();
+
+    /**
+     * When set to <code>false</code> will prevent the series data
+     * from being included in any form of data export.
+     */
+    public abstract void setIncludeInDataExport(Boolean includeInDataExport);
+
+    /**
      * @see #setKeys(String...)
      */
     public abstract String[] getKeys();
@@ -346,6 +393,16 @@ public abstract class AreaOptions extends AbstractPlotOptions {
      * A separate color for the negative part of the area.
      */
     public abstract void setNegativeFillColor(Color negativeFillColor);
+
+    /**
+     * @see #setOpacity(Number)
+     */
+    public abstract Number getOpacity();
+
+    /**
+     * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+     */
+    public abstract void setOpacity(Number opacity);
 
 
     public abstract String getPointDescriptionFormatter();

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/ColumnOptions.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/ColumnOptions.java
@@ -82,6 +82,16 @@ public abstract class ColumnOptions extends AbstractPlotOptions {
     public abstract void setBorderWidth(Number borderWidth);
 
     /**
+     * @see #setClip(Boolean)
+     */
+    public abstract Boolean getClip();
+
+    /**
+     * Disable this option to allow series rendering in the whole plotting area.
+     */
+    public abstract void setClip(Boolean clip);
+
+    /**
      * @see #setColorByPoint(Boolean)
      */
     public abstract Boolean getColorByPoint();
@@ -92,6 +102,18 @@ public abstract class ColumnOptions extends AbstractPlotOptions {
      * the chart should receive one color per series or one color per point.
      */
     public abstract void setColorByPoint(Boolean colorByPoint);
+
+    /**
+     * @see #setColorKey(String)
+     */
+    public abstract String getColorKey();
+
+    /**
+     * Determines what data value should be used to calculate point color if colorAxis is used.
+     * Requires to set <code>min</code> and <code>max</code> if some custom point property is used
+     * or if approximation for data grouping is set to <code>'sum'</code>'.
+     */
+    public abstract void setColorKey(String colorKey);
 
     /**
      * @see #setColors(Color...)
@@ -121,6 +143,20 @@ public abstract class ColumnOptions extends AbstractPlotOptions {
      * @see #setColors(Color...)
      */
     public abstract void removeColor(Color color);
+
+    /**
+     * @see #setCrisp(Boolean)
+     */
+    public abstract Boolean getCrisp();
+
+    /**
+     * When true, each point or column edge is rounded to its nearest pixel in order to render sharp on screen.
+     * In some cases, when there are a lot of densely packed columns, this leads to visible difference
+     * in column widths or distance between columns.
+     * In these cases, setting crisp to false may look better,
+     * even though each column is rendered blurry.
+     */
+    public abstract void setCrisp(Boolean crisp);
 
     /**
      * @see #setCursor(Cursor)
@@ -262,6 +298,16 @@ public abstract class ColumnOptions extends AbstractPlotOptions {
      * also toggles the linked series.
      */
     public abstract void setLinkedTo(String linkedTo);
+
+    /**
+     * @see #setOpacity(Number)
+     */
+    public abstract Number getOpacity();
+
+    /**
+     * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+     */
+    public abstract void setOpacity(Number opacity);
 
     /**
      * @see #setMaxPointWidth(Number)

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/GaugeOptions.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/GaugeOptions.java
@@ -38,6 +38,32 @@ public abstract class GaugeOptions extends AbstractPlotOptions {
     public abstract void setAnimation(Boolean animation);
 
     /**
+     * @see #setClip(Boolean)
+     */
+    public abstract Boolean getClip();
+
+    /**
+     * Disable this option to allow series rendering in the whole plotting area.
+     * Note that clipping should be always enabled when chart.zoomType is set
+     */
+    public abstract void setClip(Boolean clip);
+
+    /**
+     * @see #setCrisp(Boolean)
+     */
+    public abstract Boolean getCrisp();
+
+    /**
+     * When true, each point or column edge is rounded to its nearest pixel
+     * in order to render sharp on screen. In some cases,
+     * when there are a lot of densely packed columns, this leads to
+     * visible difference in column widths or distance between columns.
+     * In these cases, setting <code>crisp</code> to <code>false</code>
+     * may look better, even though each column is rendered blurry.
+     */
+    public abstract void setCrisp(Boolean crisp);
+
+    /**
      * @see #setCursor(Cursor)
      */
     public abstract Cursor getCursor();
@@ -113,6 +139,16 @@ public abstract class GaugeOptions extends AbstractPlotOptions {
      * @see #setKeys(String...)
      */
     public abstract void removeKey(String key);
+
+    /**
+     * @see #setOpacity(Number)
+     */
+    public abstract Number getOpacity();
+
+    /**
+     * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+     */
+    public abstract void setOpacity(Number opacity);
 
     /**
      * @see #setOvershoot(Number)

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/OhlcOptions.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/OhlcOptions.java
@@ -17,10 +17,10 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import com.vaadin.flow.component.charts.model.style.Color;
-
 import java.time.Instant;
 import java.util.Date;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 
 public abstract class OhlcOptions extends AbstractPlotOptions {
 
@@ -80,6 +80,34 @@ public abstract class OhlcOptions extends AbstractPlotOptions {
     public abstract void setClassName(String className);
 
     /**
+     * @see #setClip(Boolean)
+     */
+    public abstract Boolean getClip();
+
+    /**
+     * Disable this option to allow series rendering in the whole plotting area.
+     */
+    public abstract void setClip(Boolean clip);
+
+    /**
+     * @see #setColorByPoint(Boolean)
+     */
+    public abstract Boolean getColorByPoint();
+
+    /**
+     * When using automatic point colors pulled from the global colors
+     * or series-specific plotOptions.column.colors collections,
+     * this option determines whether the chart should receive
+     * one color per series or one color per point.
+     * <p>
+     * In styled mode, the <code>colors</code> or <code>series.colors</code>
+     * arrays are not supported,
+     * and instead this option gives the points individual color class names
+     * on the form <code>highcharts-color-{n}</code>.
+     */
+    public abstract void setColorByPoint(Boolean colorByPoint);
+
+    /**
      * @see #setColorIndex(Number)
      */
     public abstract Number getColorIndex();
@@ -90,6 +118,20 @@ public abstract class OhlcOptions extends AbstractPlotOptions {
      * <code>highcharts-color-{n}</code>.
      */
     public abstract void setColorIndex(Number colorIndex);
+
+    /**
+     * @see #setColorKey(String)
+     */
+    public abstract String getColorKey();
+
+    /**
+     * Determines what data value should be used to calculate point color
+     * if <code>colorAxis</code> is used.
+     * Requires to set <code>min</code> and <code>max</code>
+     * if some custom point property is used
+     * or if approximation for data grouping is set to <code>'sum'</code>.
+     */
+    public abstract void setColorKey(String colorKey);
 
     /**
      * @see #setColors(Color...)
@@ -377,6 +419,16 @@ public abstract class OhlcOptions extends AbstractPlotOptions {
      * <code>showInNavigator</code> is <code>true</code> for this series.
      */
     public abstract void setNavigatorOptions(PlotOptionsSeries navigatorOptions);
+
+    /**
+     * @see #setOpacity(Number)
+     */
+    public abstract Number getOpacity();
+
+    /**
+     * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+     */
+    public abstract void setOpacity(Number opacity);
 
     public abstract String getPointDescriptionFormatter();
 

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArea.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArea.java
@@ -167,7 +167,7 @@ public class PlotOptionsArea extends AreaOptions {
 	}
 
 	/**
-	 * @see setClip(Boolean)
+	 * @see #setClip(Boolean)
 	 */
 	public Boolean getClip() {
 		return clip;
@@ -233,7 +233,7 @@ public class PlotOptionsArea extends AreaOptions {
 	}
 
 	/**
-	 * @see setColorKey(String)
+	 * @see #setColorKey(String)
 	 */
 	public String getColorKey() {
 		return colorKey;
@@ -717,7 +717,7 @@ public class PlotOptionsArea extends AreaOptions {
 	}
 
 	/**
-	 * @see setOpacity(Boolean)
+	 * @see #setOpacity(Number)
 	 */
 	public Number getOpacity() {
 		return opacity;

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArea.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArea.java
@@ -33,10 +33,13 @@ public class PlotOptionsArea extends AreaOptions {
 	private Boolean animation;
 	private Number animationLimit;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Number colorIndex;
+	private String colorKey;
 	private Boolean connectEnds;
 	private Boolean connectNulls;
+	private Boolean crisp;
 	private Number cropThreshold;
 	private Cursor cursor;
 	private DashStyle dashStyle;
@@ -48,6 +51,7 @@ public class PlotOptionsArea extends AreaOptions {
 	private Number fillOpacity;
 	private Dimension findNearestPointBy;
 	private Boolean getExtremesFromAll;
+	private Boolean includeInDataExport;
 	private ArrayList<String> keys;
 	private Color lineColor;
 	private Number lineWidth;
@@ -56,6 +60,7 @@ public class PlotOptionsArea extends AreaOptions {
 	private Marker marker;
 	private Color negativeColor;
 	private Color negativeFillColor;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -163,6 +168,23 @@ public class PlotOptionsArea extends AreaOptions {
 	}
 
 	/**
+	 * @see setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -212,6 +234,24 @@ public class PlotOptionsArea extends AreaOptions {
 	}
 
 	/**
+	 * @see setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color if <code>colorAxis</code> is used.
+	 * Requires to set min and max if some custom point property is used
+	 * or if approximation for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>y</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
+	}
+
+	/**
 	 * @see #setConnectEnds(Boolean)
 	 */
 	public Boolean getConnectEnds() {
@@ -242,6 +282,22 @@ public class PlotOptionsArea extends AreaOptions {
 	 */
 	public void setConnectNulls(Boolean connectNulls) {
 		this.connectNulls = connectNulls;
+	}
+
+	public Boolean getCrisp() {
+		return crisp;
+	}
+
+	/**
+	 * When true, each point or column edge is rounded to its nearest pixel in order to render sharp on screen.
+	 * In some cases, when there are a lot of densely packed columns, this leads to visible difference in column widths
+	 * or distance between columns.
+	 * In these cases, setting crisp to false may look better, even though each column is rendered blurry.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setCrisp(Boolean crisp) {
+		this.crisp = crisp;
 	}
 
 	/**
@@ -488,6 +544,21 @@ public class PlotOptionsArea extends AreaOptions {
 	}
 
 	/**
+	 * @see setIncludeInDataExport(Boolean)
+	 */
+	public Boolean getIncludeInDataExport() {
+		return includeInDataExport;
+	}
+
+	/**
+	 * When set to <code>false</code> will prevent the series data
+	 * from being included in any form of data export.
+	 */
+	public void setIncludeInDataExport(Boolean includeInDataExport) {
+		this.includeInDataExport = includeInDataExport;
+	}
+
+	/**
 	 * @see #setKeys(String...)
 	 */
 	public String[] getKeys() {
@@ -659,6 +730,22 @@ public class PlotOptionsArea extends AreaOptions {
 	 */
 	public void setNegativeFillColor(Color negativeFillColor) {
 		this.negativeFillColor = negativeFillColor;
+	}
+
+	/**
+	 * @see setOpacity(Boolean)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArea.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArea.java
@@ -51,7 +51,6 @@ public class PlotOptionsArea extends AreaOptions {
 	private Number fillOpacity;
 	private Dimension findNearestPointBy;
 	private Boolean getExtremesFromAll;
-	private Boolean includeInDataExport;
 	private ArrayList<String> keys;
 	private Color lineColor;
 	private Number lineWidth;
@@ -541,21 +540,6 @@ public class PlotOptionsArea extends AreaOptions {
 	 */
 	public void setGetExtremesFromAll(Boolean getExtremesFromAll) {
 		this.getExtremesFromAll = getExtremesFromAll;
-	}
-
-	/**
-	 * @see setIncludeInDataExport(Boolean)
-	 */
-	public Boolean getIncludeInDataExport() {
-		return includeInDataExport;
-	}
-
-	/**
-	 * When set to <code>false</code> will prevent the series data
-	 * from being included in any form of data export.
-	 */
-	public void setIncludeInDataExport(Boolean includeInDataExport) {
-		this.includeInDataExport = includeInDataExport;
 	}
 
 	/**

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArearange.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArearange.java
@@ -54,7 +54,6 @@ public class PlotOptionsArearange extends AreaOptions {
 	private Number fillOpacity;
 	private Dimension findNearestPointBy;
 	private Boolean getExtremesFromAll;
-	private Boolean includeInDataExport;
 	private ArrayList<String> keys;
 	private Color lineColor;
 	private Number lineWidth;
@@ -521,22 +520,6 @@ public class PlotOptionsArearange extends AreaOptions {
 	 */
 	public void setGetExtremesFromAll(Boolean getExtremesFromAll) {
 		this.getExtremesFromAll = getExtremesFromAll;
-	}
-
-	/**
-	 * @see #setIncludeInDataExport(Boolean)
-	 */
-	public Boolean getIncludeInDataExport() {
-		return includeInDataExport;
-	}
-
-	/**
-	 * When set to <code>false</code> will prevent the series data from being included in any form of data export.
-	 * <p>
-	 * Defaults to <code>undefined</code>.
-	 */
-	public void setIncludeInDataExport(Boolean includeInDataExport) {
-		this.includeInDataExport = includeInDataExport;
 	}
 
 	/**

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArearange.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArearange.java
@@ -169,7 +169,7 @@ public class PlotOptionsArearange extends AreaOptions {
 	}
 
 	/**
-	 * @see setClip(Boolean)
+	 * @see #setClip(Boolean)
 	 */
 	public Boolean getClip() {
 		return clip;
@@ -235,7 +235,7 @@ public class PlotOptionsArearange extends AreaOptions {
 	}
 
 	/**
-	 * @see setColorKey(String)
+	 * @see #setColorKey(String)
 	 */
 	public String getColorKey() {
 		return colorKey;
@@ -269,7 +269,7 @@ public class PlotOptionsArearange extends AreaOptions {
 	}
 
 	/**
-	 * @see setCrisp(Boolean)
+	 * @see #setCrisp(Boolean)
 	 */
 	public Boolean getCrisp() {
 		return crisp;
@@ -524,7 +524,7 @@ public class PlotOptionsArearange extends AreaOptions {
 	}
 
 	/**
-	 * @see setIncludeInDataExport(Boolean)
+	 * @see #setIncludeInDataExport(Boolean)
 	 */
 	public Boolean getIncludeInDataExport() {
 		return includeInDataExport;
@@ -683,7 +683,7 @@ public class PlotOptionsArearange extends AreaOptions {
 	}
 
 	/**
-	 * @see setOpacity(Number)
+	 * @see #setOpacity(Number)
 	 */
 	public Number getOpacity() {
 		return opacity;

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArearange.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArearange.java
@@ -17,13 +17,13 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.time.Instant;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
 /**
@@ -37,9 +37,12 @@ public class PlotOptionsArearange extends AreaOptions {
 	private Boolean animation;
 	private Number animationLimit;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Number colorIndex;
+	private String colorKey;
 	private Boolean connectNulls;
+	private Boolean crisp;
 	private Number cropThreshold;
 	private Cursor cursor;
 	private DashStyle dashStyle;
@@ -51,6 +54,7 @@ public class PlotOptionsArearange extends AreaOptions {
 	private Number fillOpacity;
 	private Dimension findNearestPointBy;
 	private Boolean getExtremesFromAll;
+	private Boolean includeInDataExport;
 	private ArrayList<String> keys;
 	private Color lineColor;
 	private Number lineWidth;
@@ -58,6 +62,7 @@ public class PlotOptionsArearange extends AreaOptions {
 	private String linkedTo;
 	private Color negativeColor;
 	private Color negativeFillColor;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -164,6 +169,23 @@ public class PlotOptionsArearange extends AreaOptions {
 	}
 
 	/**
+	 * @see setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -213,6 +235,24 @@ public class PlotOptionsArearange extends AreaOptions {
 	}
 
 	/**
+	 * @see setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color if <code>colorAxis</code> is used.
+	 * Requires to set <code>min</code> and <code>max</code> if some custom point property is used or
+	 * if approximation for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>low</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
+	}
+
+	/**
 	 * @see #setConnectNulls(Boolean)
 	 */
 	public Boolean getConnectNulls() {
@@ -226,6 +266,26 @@ public class PlotOptionsArearange extends AreaOptions {
 	 */
 	public void setConnectNulls(Boolean connectNulls) {
 		this.connectNulls = connectNulls;
+	}
+
+	/**
+	 * @see setCrisp(Boolean)
+	 */
+	public Boolean getCrisp() {
+		return crisp;
+	}
+
+	/**
+	 * When true, each point or column edge is rounded to its nearest pixel in order to render sharp on screen.
+	 * In some cases, when there are a lot of densely packed columns,
+	 * this leads to visible difference in column widths or distance between columns.
+	 * In these cases, setting <code>crisp</code> to <code>false</code> may look better,
+	 * even though each column is rendered blurry.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setCrisp(Boolean crisp) {
+		this.crisp = crisp;
 	}
 
 	/**
@@ -464,6 +524,22 @@ public class PlotOptionsArearange extends AreaOptions {
 	}
 
 	/**
+	 * @see setIncludeInDataExport(Boolean)
+	 */
+	public Boolean getIncludeInDataExport() {
+		return includeInDataExport;
+	}
+
+	/**
+	 * When set to <code>false</code> will prevent the series data from being included in any form of data export.
+	 * <p>
+	 * Defaults to <code>undefined</code>.
+	 */
+	public void setIncludeInDataExport(Boolean includeInDataExport) {
+		this.includeInDataExport = includeInDataExport;
+	}
+
+	/**
 	 * @see #setKeys(String...)
 	 */
 	public String[] getKeys() {
@@ -604,6 +680,22 @@ public class PlotOptionsArearange extends AreaOptions {
 	 */
 	public void setNegativeFillColor(Color negativeFillColor) {
 		this.negativeFillColor = negativeFillColor;
+	}
+
+	/**
+	 * @see setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreaspline.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreaspline.java
@@ -17,13 +17,13 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.time.Instant;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
 @Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
@@ -33,10 +33,13 @@ public class PlotOptionsAreaspline extends AreaOptions {
 	private Boolean animation;
 	private Number animationLimit;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Number colorIndex;
+	private String colorKey;
 	private Boolean connectEnds;
 	private Boolean connectNulls;
+	private Boolean crisp;
 	private Number cropThreshold;
 	private Cursor cursor;
 	private DashStyle dashStyle;
@@ -48,6 +51,7 @@ public class PlotOptionsAreaspline extends AreaOptions {
 	private Number fillOpacity;
 	private Dimension findNearestPointBy;
 	private Boolean getExtremesFromAll;
+	private Boolean includeInDataExport;
 	private ArrayList<String> keys;
 	private Color lineColor;
 	private Number lineWidth;
@@ -56,6 +60,7 @@ public class PlotOptionsAreaspline extends AreaOptions {
 	private Marker marker;
 	private Color negativeColor;
 	private Color negativeFillColor;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -162,6 +167,23 @@ public class PlotOptionsAreaspline extends AreaOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -211,6 +233,24 @@ public class PlotOptionsAreaspline extends AreaOptions {
 	}
 
 	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color if <code>colorAxis</code> is used.
+	 * Requires to set <code>min</code> and <code>max</code> if some custom point property is used
+	 * or if approximation for data grouping is set to 'sum'.
+	 * <p>
+	 * Defaults to <code>y</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
+	}
+
+	/**
 	 * @see #setConnectEnds(Boolean)
 	 */
 	public Boolean getConnectEnds() {
@@ -241,6 +281,26 @@ public class PlotOptionsAreaspline extends AreaOptions {
 	 */
 	public void setConnectNulls(Boolean connectNulls) {
 		this.connectNulls = connectNulls;
+	}
+
+	/**
+	 * @see #setCrisp(Boolean)
+	 */
+	public Boolean getCrisp() {
+		return crisp;
+	}
+
+	/**
+	 * When true, each point or column edge is rounded to its nearest pixel in order to render sharp on screen.
+	 * In some cases, when there are a lot of densely packed columns, this leads to visible difference
+	 * in column widths or distance between columns.
+	 * In these cases, setting <code>crisp</code> to <code>false</code> may look better,
+	 * even though each column is rendered blurry.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setCrisp(Boolean crisp) {
+		this.crisp = crisp;
 	}
 
 	/**
@@ -487,6 +547,22 @@ public class PlotOptionsAreaspline extends AreaOptions {
 	}
 
 	/**
+	 * @see #setIncludeInDataExport(Boolean)
+	 */
+	public Boolean getIncludeInDataExport() {
+		return includeInDataExport;
+	}
+
+	/**
+	 * When set to <code>false</code> will prevent the series data from being included in any form of data export.
+	 * <p>
+	 * Defaults to <code>undefined</code>.
+	 */
+	public void setIncludeInDataExport(Boolean includeInDataExport) {
+		this.includeInDataExport = includeInDataExport;
+	}
+
+	/**
 	 * @see #setKeys(String...)
 	 */
 	public String[] getKeys() {
@@ -658,6 +734,22 @@ public class PlotOptionsAreaspline extends AreaOptions {
 	 */
 	public void setNegativeFillColor(Color negativeFillColor) {
 		this.negativeFillColor = negativeFillColor;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreaspline.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreaspline.java
@@ -51,7 +51,6 @@ public class PlotOptionsAreaspline extends AreaOptions {
 	private Number fillOpacity;
 	private Dimension findNearestPointBy;
 	private Boolean getExtremesFromAll;
-	private Boolean includeInDataExport;
 	private ArrayList<String> keys;
 	private Color lineColor;
 	private Number lineWidth;
@@ -544,22 +543,6 @@ public class PlotOptionsAreaspline extends AreaOptions {
 	 */
 	public void setGetExtremesFromAll(Boolean getExtremesFromAll) {
 		this.getExtremesFromAll = getExtremesFromAll;
-	}
-
-	/**
-	 * @see #setIncludeInDataExport(Boolean)
-	 */
-	public Boolean getIncludeInDataExport() {
-		return includeInDataExport;
-	}
-
-	/**
-	 * When set to <code>false</code> will prevent the series data from being included in any form of data export.
-	 * <p>
-	 * Defaults to <code>undefined</code>.
-	 */
-	public void setIncludeInDataExport(Boolean includeInDataExport) {
-		this.includeInDataExport = includeInDataExport;
 	}
 
 	/**

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreasplinerange.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreasplinerange.java
@@ -17,13 +17,13 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.time.Instant;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
 /**
@@ -37,9 +37,12 @@ public class PlotOptionsAreasplinerange extends AreaOptions {
 	private Boolean animation;
 	private Number animationLimit;
 	private String className;
+	private Boolean clip;
 	private Color color;
+	private String colorKey;
 	private Number colorIndex;
 	private Boolean connectNulls;
+	private Boolean crisp;
 	private Number cropThreshold;
 	private Cursor cursor;
 	private DashStyle dashStyle;
@@ -51,6 +54,7 @@ public class PlotOptionsAreasplinerange extends AreaOptions {
 	private Number fillOpacity;
 	private Dimension findNearestPointBy;
 	private Boolean getExtremesFromAll;
+	private Boolean includeInDataExport;
 	private ArrayList<String> keys;
 	private Color lineColor;
 	private Number lineWidth;
@@ -58,6 +62,7 @@ public class PlotOptionsAreasplinerange extends AreaOptions {
 	private String linkedTo;
 	private Color negativeColor;
 	private Color negativeFillColor;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -162,6 +167,23 @@ public class PlotOptionsAreasplinerange extends AreaOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -211,6 +233,25 @@ public class PlotOptionsAreasplinerange extends AreaOptions {
 	}
 
 	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color
+	 * if <code>colorAxis</code> is used.
+	 * Requires to set <code>min</code> and <code>max</code> if some custom point property is used
+	 * or if approximation for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>low</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
+	}
+
+	/**
 	 * @see #setConnectNulls(Boolean)
 	 */
 	public Boolean getConnectNulls() {
@@ -224,6 +265,27 @@ public class PlotOptionsAreasplinerange extends AreaOptions {
 	 */
 	public void setConnectNulls(Boolean connectNulls) {
 		this.connectNulls = connectNulls;
+	}
+
+	/**
+	 * @see #setCrisp(Boolean)
+	 */
+	public Boolean getCrisp() {
+		return crisp;
+	}
+
+	/**
+	 * When true, each point or column edge is rounded to its nearest pixel in order
+	 * to render sharp on screen.
+	 * In some cases, when there are a lot of densely packed columns,
+	 * this leads to visible difference in column widths or distance between columns.
+	 * In these cases, setting <code>crisp</code> to <code>false</code> may look better,
+	 * even though each column is rendered blurry.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setCrisp(Boolean crisp) {
+		this.crisp = crisp;
 	}
 
 	/**
@@ -462,6 +524,23 @@ public class PlotOptionsAreasplinerange extends AreaOptions {
 	}
 
 	/**
+	 * @see #setIncludeInDataExport(Boolean)
+	 */
+	public Boolean getIncludeInDataExport() {
+		return includeInDataExport;
+	}
+
+	/**
+	 * When set to <code>false</code> will prevent the series data from being included
+	 * in any form of data export.
+	 * <p>
+	 * Defaults to <code>undefined</code>.
+	 */
+	public void setIncludeInDataExport(Boolean includeInDataExport) {
+		this.includeInDataExport = includeInDataExport;
+	}
+
+	/**
 	 * @see #setKeys(String...)
 	 */
 	public String[] getKeys() {
@@ -602,6 +681,22 @@ public class PlotOptionsAreasplinerange extends AreaOptions {
 	 */
 	public void setNegativeFillColor(Color negativeFillColor) {
 		this.negativeFillColor = negativeFillColor;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreasplinerange.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreasplinerange.java
@@ -54,7 +54,6 @@ public class PlotOptionsAreasplinerange extends AreaOptions {
 	private Number fillOpacity;
 	private Dimension findNearestPointBy;
 	private Boolean getExtremesFromAll;
-	private Boolean includeInDataExport;
 	private ArrayList<String> keys;
 	private Color lineColor;
 	private Number lineWidth;
@@ -523,22 +522,6 @@ public class PlotOptionsAreasplinerange extends AreaOptions {
 		this.getExtremesFromAll = getExtremesFromAll;
 	}
 
-	/**
-	 * @see #setIncludeInDataExport(Boolean)
-	 */
-	public Boolean getIncludeInDataExport() {
-		return includeInDataExport;
-	}
-
-	/**
-	 * When set to <code>false</code> will prevent the series data from being included
-	 * in any form of data export.
-	 * <p>
-	 * Defaults to <code>undefined</code>.
-	 */
-	public void setIncludeInDataExport(Boolean includeInDataExport) {
-		this.includeInDataExport = includeInDataExport;
-	}
 
 	/**
 	 * @see #setKeys(String...)

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBar.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBar.java
@@ -17,13 +17,13 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.time.Instant;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
 @Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
@@ -36,9 +36,11 @@ public class PlotOptionsBar extends ColumnOptions {
 	private Number borderRadius;
 	private Number borderWidth;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Boolean colorByPoint;
 	private Number colorIndex;
+	private String colorKey;
 	private ArrayList<Color> colors;
 	private Boolean crisp;
 	private Number cropThreshold;
@@ -60,6 +62,7 @@ public class PlotOptionsBar extends ColumnOptions {
 	private Number maxPointWidth;
 	private Number minPointLength;
 	private Color negativeColor;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -211,6 +214,23 @@ public class PlotOptionsBar extends ColumnOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setClassName(String)
 	 */
 	public String getClassName() {
@@ -271,6 +291,24 @@ public class PlotOptionsBar extends ColumnOptions {
 	 */
 	public void setColorByPoint(Boolean colorByPoint) {
 		this.colorByPoint = colorByPoint;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color if <code>colorAxis</code> is used.
+	 * Requires to set <code>min</code> and <code>amx</code> if some custom point property is used
+	 * or if approximation for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>y</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
 	}
 
 	/**
@@ -679,6 +717,22 @@ public class PlotOptionsBar extends ColumnOptions {
 	 */
 	public void setLinkedTo(String linkedTo) {
 		this.linkedTo = linkedTo;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	/**

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBoxplot.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBoxplot.java
@@ -17,13 +17,13 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.time.Instant;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
 /**
@@ -38,9 +38,11 @@ public class PlotOptionsBoxplot extends AbstractPlotOptions {
 	private Boolean allowPointSelect;
 	private Number animationLimit;
 	private String className;
+	private	Boolean clip;
 	private Color color;
 	private Boolean colorByPoint;
 	private Number colorIndex;
+	private String colorKey;
 	private ArrayList<Color> colors;
 	private Boolean crisp;
 	private Cursor cursor;
@@ -63,6 +65,7 @@ public class PlotOptionsBoxplot extends AbstractPlotOptions {
 	private Color medianColor;
 	private Number medianWidth;
 	private Color negativeColor;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -147,6 +150,23 @@ public class PlotOptionsBoxplot extends AbstractPlotOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -211,6 +231,24 @@ public class PlotOptionsBoxplot extends AbstractPlotOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color if colorAxis is used.
+	 * Requires to set <code>min</code> and <code>max</code> if some custom point property is used
+	 * or if approximation for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>high</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
 	}
 
 	/**
@@ -669,6 +707,22 @@ public class PlotOptionsBoxplot extends AbstractPlotOptions {
 	 */
 	public void setNegativeColor(Color negativeColor) {
 		this.negativeColor = negativeColor;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBubble.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBubble.java
@@ -17,13 +17,13 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.time.Instant;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
 /**
@@ -39,8 +39,11 @@ public class PlotOptionsBubble extends AbstractPlotOptions {
 	private Boolean animation;
 	private Number animationLimit;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Number colorIndex;
+	private String colorKey;
+	private Boolean crisp;
 	private Number cropThreshold;
 	private Cursor cursor;
 	private DashStyle dashStyle;
@@ -58,6 +61,7 @@ public class PlotOptionsBubble extends AbstractPlotOptions {
 	private String maxSize;
 	private String minSize;
 	private Color negativeColor;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -156,6 +160,23 @@ public class PlotOptionsBubble extends AbstractPlotOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -202,6 +223,44 @@ public class PlotOptionsBubble extends AbstractPlotOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color if <code>colorAxis</code> is used.
+	 * Requires to set <code>min</code> and <code>max</code> if some custom point property is used
+	 * or if approximation for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>z</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
+	}
+	/**
+	 * @see #setCrisp(Boolean)
+	 */
+	public Boolean getCrisp() {
+		return crisp;
+	}
+
+	/**
+	 * When true, each point or column edge is rounded to its nearest pixel
+	 * in order to render sharp on screen.
+	 * In some cases, when there are a lot of densely packed columns,
+	 * this leads to visible difference in column widths or distance between columns.
+	 * In these cases, setting <code>crisp</code> to <code>false</code> may look better,
+	 * even though each column is rendered blurry.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setCrisp(Boolean crisp) {
+		this.crisp = crisp;
 	}
 
 	/**
@@ -596,6 +655,22 @@ public class PlotOptionsBubble extends AbstractPlotOptions {
 	 */
 	public void setNegativeColor(Color negativeColor) {
 		this.negativeColor = negativeColor;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsCandlestick.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsCandlestick.java
@@ -17,13 +17,13 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.time.Instant;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
 /**
@@ -36,8 +36,11 @@ public class PlotOptionsCandlestick extends OhlcOptions {
 	private Boolean animation;
 	private Number animationLimit;
 	private String className;
+	private Boolean clip;
 	private Color color;
+	private Boolean colorByPoint;
 	private Number colorIndex;
+	private String colorKey;
 	private ArrayList<Color> colors;
 	private Number compareBase;
 	private Number cropThreshold;
@@ -60,6 +63,7 @@ public class PlotOptionsCandlestick extends OhlcOptions {
 	private Number minPointLength;
 	private PlotOptionsSeries navigatorOptions;
 	private Color negativeColor;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -161,6 +165,47 @@ public class PlotOptionsCandlestick extends OhlcOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
+	 * @see #setColorByPoint(Boolean)
+	 */
+	public Boolean getColorByPoint() {
+		return colorByPoint;
+	}
+
+	/**
+	 * When using automatic point colors pulled from the global colors
+	 * or series-specific plotOptions.column.colors collections,
+	 * this option determines whether the chart should receive
+	 * one color per series or one color per point.
+	 * <p>
+	 * In styled mode, the <code>colors</code> or <code>series.colors</code> arrays
+   * are not supported,
+	 * and instead this option gives the points individual color class names
+	 * on the form <code>highcharts-color-{n}</code>.
+	 * <p>
+	 * Defaults to <code>false</code>.
+	 */
+	public void setColorByPoint(Boolean colorByPoint) {
+		this.colorByPoint = colorByPoint;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -207,6 +252,25 @@ public class PlotOptionsCandlestick extends OhlcOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color
+   * if <code>colorAxis</code> is used.
+	 * Requires to set <code>min</code> and <code>max</code> if some custom point property
+	 * is used or if approximation for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>close</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
 	}
 
 	/**
@@ -678,6 +742,22 @@ public class PlotOptionsCandlestick extends OhlcOptions {
 	 */
 	public void setNavigatorOptions(PlotOptionsSeries navigatorOptions) {
 		this.navigatorOptions = navigatorOptions;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	/**

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsColumn.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsColumn.java
@@ -36,9 +36,11 @@ public class PlotOptionsColumn extends ColumnOptions {
 	private Number borderRadius;
 	private Number borderWidth;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Boolean colorByPoint;
 	private Number colorIndex;
+	private String colorKey;
 	private ArrayList<Color> colors;
 	private Boolean crisp;
 	private Number cropThreshold;
@@ -60,6 +62,7 @@ public class PlotOptionsColumn extends ColumnOptions {
 	private Number maxPointWidth;
 	private Number minPointLength;
 	private Color negativeColor;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -232,6 +235,23 @@ public class PlotOptionsColumn extends ColumnOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set
+	 * <p>
+	 * Defaults to <code>false</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -296,6 +316,27 @@ public class PlotOptionsColumn extends ColumnOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point
+	 * color if <code>colorAxis</code> is used.
+	 * Requires to set min and max if some custom point property is used or if approximation
+	 * for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>y</code>.
+	 *
+	 * @param colorKey
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
 	}
 
 	/**
@@ -701,6 +742,24 @@ public class PlotOptionsColumn extends ColumnOptions {
 	 */
 	public void setLinkedTo(String linkedTo) {
 		this.linkedTo = linkedTo;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	@Override
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	@Override
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	/**

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsColumnrange.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsColumnrange.java
@@ -17,13 +17,13 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.time.Instant;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
 /**
@@ -42,9 +42,11 @@ public class PlotOptionsColumnrange extends ColumnOptions {
 	private Number borderRadius;
 	private Number borderWidth;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Boolean colorByPoint;
 	private Number colorIndex;
+	private String colorKey;
 	private ArrayList<Color> colors;
 	private Boolean crisp;
 	private Number cropThreshold;
@@ -65,6 +67,7 @@ public class PlotOptionsColumnrange extends ColumnOptions {
 	private String linkedTo;
 	private Number maxPointWidth;
 	private Number minPointLength;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -220,6 +223,23 @@ public class PlotOptionsColumnrange extends ColumnOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setClassName(String)
 	 */
 	public String getClassName() {
@@ -280,6 +300,24 @@ public class PlotOptionsColumnrange extends ColumnOptions {
 	 */
 	public void setColorByPoint(Boolean colorByPoint) {
 		this.colorByPoint = colorByPoint;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color if <code>colorAxis</code> is used.
+	 * Requires to set <code>min</code> and <code>max</code> if some custom point property is used
+	 * or if approximation for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>y</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
 	}
 
 	/**
@@ -695,6 +733,22 @@ public class PlotOptionsColumnrange extends ColumnOptions {
 	 */
 	public void setLinkedTo(String linkedTo) {
 		this.linkedTo = linkedTo;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	/**

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsErrorbar.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsErrorbar.java
@@ -37,9 +37,11 @@ public class PlotOptionsErrorbar extends AbstractPlotOptions {
 	private Boolean allowPointSelect;
 	private Number animationLimit;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Boolean colorByPoint;
 	private Number colorIndex;
+	private String colorKey;
 	private ArrayList<Color> colors;
 	private Boolean crisp;
 	private Cursor cursor;
@@ -57,6 +59,7 @@ public class PlotOptionsErrorbar extends AbstractPlotOptions {
 	private String linkedTo;
 	private Number maxPointWidth;
 	private Color negativeColor;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -139,6 +142,24 @@ public class PlotOptionsErrorbar extends AbstractPlotOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 * @return
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -190,6 +211,26 @@ public class PlotOptionsErrorbar extends AbstractPlotOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color
+	 * if <code>colorAxis</code> is used.
+	 * Requires to set <code>min</code> and <code>max</code>
+	 * if some custom point property is used or if approximation for data grouping
+	 * is set to <code>`sum'</code>.
+	 * <p>
+	 * Defaults to <code>high</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
 	}
 
 	/**
@@ -564,6 +605,21 @@ public class PlotOptionsErrorbar extends AbstractPlotOptions {
 	 */
 	public void setNegativeColor(Color negativeColor) {
 		this.negativeColor = negativeColor;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsFlags.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsFlags.java
@@ -17,11 +17,11 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.model.style.Style;
 
 /**
@@ -33,10 +33,13 @@ public class PlotOptionsFlags extends AbstractPlotOptions {
 	private Boolean allowPointSelect;
 	private Number animationLimit;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Number colorIndex;
+	private String colorKey;
 	private ArrayList<Color> colors;
 	private Number compareBase;
+	private Boolean crisp;
 	private Number cropThreshold;
 	private Cursor cursor;
 	private String description;
@@ -55,6 +58,7 @@ public class PlotOptionsFlags extends AbstractPlotOptions {
 	private Color negativeColor;
 	private String onKey;
 	private String onSeries;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private IntervalUnit pointIntervalUnit;
 	private Boolean selected;
@@ -136,6 +140,23 @@ public class PlotOptionsFlags extends AbstractPlotOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -182,6 +203,25 @@ public class PlotOptionsFlags extends AbstractPlotOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color
+	 * if <code>colorAxis</code> is used. Requires to set <code>min</code>
+	 * and <code>max</code> if some custom point property is used
+	 * or if approximation for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>y</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
 	}
 
 	/**
@@ -246,6 +286,27 @@ public class PlotOptionsFlags extends AbstractPlotOptions {
 	 */
 	public void setCompareBase(Number compareBase) {
 		this.compareBase = compareBase;
+	}
+
+	/**
+	 * @see #setCrisp(Boolean)
+	 */
+	public Boolean getCrisp() {
+		return crisp;
+	}
+
+	/**
+	 * When true, each point or column edge is rounded to its nearest pixel
+	 * in order to render sharp on screen. In some cases, when there are a lot of
+	 * densely packed columns, this leads to visible difference in column widths
+	 * or distance between columns. In these cases, setting <code>crisp</code>
+	 * to <code>false</code> may look better, even though each column
+	 * is rendered blurry.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setCrisp(Boolean crisp) {
+		this.crisp = crisp;
 	}
 
 	/**
@@ -631,6 +692,22 @@ public class PlotOptionsFlags extends AbstractPlotOptions {
 	 */
 	public void setOnSeries(String onSeries) {
 		this.onSeries = onSeries;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsFunnel.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsFunnel.java
@@ -17,11 +17,11 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
  * Funnel charts are a type of chart often used to visualize stages in a sales
@@ -37,8 +37,11 @@ public class PlotOptionsFunnel extends PyramidOptions {
 	private Number borderWidth;
 	private String[] center;
 	private String className;
+	private Boolean clip;
 	private Number colorIndex;
+	private String colorKey;
 	private ArrayList<Color> colors;
+	private Boolean crisp;
 	private Cursor cursor;
 	private DataLabelsFunnel dataLabels;
 	private Number depth;
@@ -48,11 +51,13 @@ public class PlotOptionsFunnel extends PyramidOptions {
 	private Dimension findNearestPointBy;
 	private Boolean getExtremesFromAll;
 	private String height;
+	private Boolean ignoreHiddenPoint;
 	private ArrayList<String> keys;
 	private String linkedTo;
 	private Number minSize;
 	private String neckHeight;
 	private String neckWidth;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Boolean reversed;
 	private Boolean selected;
@@ -196,6 +201,23 @@ public class PlotOptionsFunnel extends PyramidOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set.
+	 * <p>
+	 * Defaults to <code>false</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColorIndex(Number)
 	 */
 	public Number getColorIndex() {
@@ -211,6 +233,25 @@ public class PlotOptionsFunnel extends PyramidOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color
+	 * if <code>colorAxis</code> is used. Requires to set <code>min</code> and
+	 * <code>max</code> if some custom point property is used or if approximation
+	 * for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>y</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
 	}
 
 	/**
@@ -256,6 +297,27 @@ public class PlotOptionsFunnel extends PyramidOptions {
 	 */
 	public void removeColor(Color color) {
 		this.colors.remove(color);
+	}
+
+	/**
+	 * @see #setCrisp(Boolean)
+	 */
+	public Boolean getCrisp() {
+		return crisp;
+	}
+
+	/**
+	 * When true, each point or column edge is rounded to its nearest pixel
+	 * in order to render sharp on screen. In some cases, when there are a lot of
+	 * densely packed columns, this leads to visible difference in column widths
+	 * or distance between columns. In these cases, setting <code>crisp</code>
+	 * to <code>false</code> may look better, even though each column
+	 * is rendered blurry.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setCrisp(Boolean crisp) {
+		this.crisp = crisp;
 	}
 
 	/**
@@ -428,6 +490,23 @@ public class PlotOptionsFunnel extends PyramidOptions {
 	}
 
 	/**
+	 * @see #setIgnoreHiddenPoint(Boolean)
+	 */
+	public Boolean getIgnoreHiddenPoint() {
+		return ignoreHiddenPoint;
+	}
+
+	/**
+	 * This option tells whether the series shall be redrawn as if
+	 * the hidden point were null.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setIgnoreHiddenPoint(Boolean ignoreHiddenPoint) {
+		this.ignoreHiddenPoint = ignoreHiddenPoint;
+	}
+
+	/**
 	 * @see #setKeys(String...)
 	 */
 	public String[] getKeys() {
@@ -506,6 +585,22 @@ public class PlotOptionsFunnel extends PyramidOptions {
 	 */
 	public void setMinSize(Number minSize) {
 		this.minSize = minSize;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	/**

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsGauge.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsGauge.java
@@ -17,11 +17,11 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
  * General plotting options for the gauge series type. Requires
@@ -33,8 +33,10 @@ public class PlotOptionsGauge extends GaugeOptions {
 	private Boolean animation;
 	private Number animationLimit;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Number colorIndex;
+	private Boolean crisp;
 	private Cursor cursor;
 	private DataLabels dataLabels;
 	private String description;
@@ -46,6 +48,7 @@ public class PlotOptionsGauge extends GaugeOptions {
 	private ArrayList<String> keys;
 	private String linkedTo;
 	private Color negativeColor;
+	private Number opacity;
 	private Number overshoot;
 	private Pivot pivot;
 	private String _fn_pointDescriptionFormatter;
@@ -117,6 +120,23 @@ public class PlotOptionsGauge extends GaugeOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -163,6 +183,27 @@ public class PlotOptionsGauge extends GaugeOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setCrisp(Boolean)
+	 */
+	public Boolean getCrisp() {
+		return crisp;
+	}
+
+	/**
+	 * When true, each point or column edge is rounded to its nearest pixel
+	 * in order to render sharp on screen. In some cases, when there are a lot of
+	 * densely packed columns, this leads to visible difference in column widths
+	 * or distance between columns. In these cases, setting <code>crisp</code>
+	 * to <code>false</code> may look better, even though each column is
+	 * rendered blurry.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setCrisp(Boolean crisp) {
+		this.crisp = crisp;
 	}
 
 	/**
@@ -376,6 +417,22 @@ public class PlotOptionsGauge extends GaugeOptions {
 	 */
 	public void removeKey(String key) {
 		this.keys.remove(key);
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	/**

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsHeatmap.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsHeatmap.java
@@ -17,11 +17,11 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
  * <p>
@@ -44,9 +44,11 @@ public class PlotOptionsHeatmap extends AbstractPlotOptions {
 	private Number borderRadius;
 	private Number borderWidth;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Boolean colorByPoint;
 	private Number colorIndex;
+	private String colorKey;
 	private ArrayList<Color> colors;
 	private Number colsize;
 	private Boolean crisp;
@@ -61,6 +63,7 @@ public class PlotOptionsHeatmap extends AbstractPlotOptions {
 	private ArrayList<String> keys;
 	private String linkedTo;
 	private Number maxPointWidth;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number rowsize;
 	private Boolean selected;
@@ -217,6 +220,23 @@ public class PlotOptionsHeatmap extends AbstractPlotOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -269,6 +289,25 @@ public class PlotOptionsHeatmap extends AbstractPlotOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color
+	 * if <code>colorAxis</code> is used. Requires to set <code>min</code> and
+	 * <code>max</code> if some custom point property is used or if approximation
+	 * for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>value</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
 	}
 
 	/**
@@ -609,6 +648,22 @@ public class PlotOptionsHeatmap extends AbstractPlotOptions {
 	 */
 	public void setMaxPointWidth(Number maxPointWidth) {
 		this.maxPointWidth = maxPointWidth;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsLine.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsLine.java
@@ -17,13 +17,13 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.time.Instant;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
 @Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
@@ -33,10 +33,13 @@ public class PlotOptionsLine extends PointOptions {
 	private Boolean animation;
 	private Number animationLimit;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Number colorIndex;
+	private String colorKey;
 	private Boolean connectEnds;
 	private Boolean connectNulls;
+	private Boolean crisp;
 	private Number cropThreshold;
 	private Cursor cursor;
 	private DashStyle dashStyle;
@@ -52,6 +55,7 @@ public class PlotOptionsLine extends PointOptions {
 	private String linkedTo;
 	private Marker marker;
 	private Color negativeColor;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -158,6 +162,23 @@ public class PlotOptionsLine extends PointOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that lipping should be always enabled when chart.zoomType is set
+	 * <p>
+	 * Defaults to <code>false</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -204,6 +225,46 @@ public class PlotOptionsLine extends PointOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point
+	 * color if <code>colorAxis</code> is used.
+	 * Requires to set min and max if some custom point property is used or if approximation
+	 * for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>y</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
+	}
+
+	/**
+	 * @see #setCrisp(Boolean)
+	 */
+	public Boolean getCrisp() {
+		return crisp;
+	}
+
+	/**
+	 * When true, each point or column edge is rounded to its nearest pixel
+	 * in order to render sharp on screen. In some cases,
+	 * when there are a lot of densely packed columns, this leads to visible
+	 * difference in column widths or distance between columns. In these cases,
+	 * setting <code>crisp</code> to <code>false</code> may look better,
+	 * even though each column is rendered blurry.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setCrisp(Boolean crisp) {
+		this.crisp = crisp;
 	}
 
 	/**
@@ -587,6 +648,22 @@ public class PlotOptionsLine extends PointOptions {
 	 */
 	public void setNegativeColor(Color negativeColor) {
 		this.negativeColor = negativeColor;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	 public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsOhlc.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsOhlc.java
@@ -17,13 +17,13 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.time.Instant;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
 /**
@@ -36,9 +36,11 @@ public class PlotOptionsOhlc extends OhlcOptions {
 	private Boolean animation;
 	private Number animationLimit;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Boolean colorByPoint;
 	private Number colorIndex;
+	private String colorKey;
 	private ArrayList<Color> colors;
 	private Compare compare;
 	private Number compareBase;
@@ -61,6 +63,7 @@ public class PlotOptionsOhlc extends OhlcOptions {
 	private Number minPointLength;
 	private PlotOptionsSeries navigatorOptions;
 	private Color negativeColor;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -161,6 +164,23 @@ public class PlotOptionsOhlc extends OhlcOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -225,6 +245,26 @@ public class PlotOptionsOhlc extends OhlcOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color
+   * if <code>colorAxis</code> is used.
+	 * Requires to set <code>min</code> and <code>max</code> if some custom point
+   * property is used or if approximation for data grouping
+   * is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>close</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
 	}
 
 	/**
@@ -682,6 +722,22 @@ public class PlotOptionsOhlc extends OhlcOptions {
 	 */
 	public void setNavigatorOptions(PlotOptionsSeries navigatorOptions) {
 		this.navigatorOptions = navigatorOptions;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	/**

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsPie.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsPie.java
@@ -17,12 +17,11 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import com.vaadin.flow.component.charts.model.style.Color;
 /**
  * A pie chart is a circular chart divided into sectors, illustrating numerical
  * proportion.
@@ -37,8 +36,11 @@ public class PlotOptionsPie extends AbstractPlotOptions {
 	private Number borderWidth;
 	private String[] center;
 	private String className;
+	private Boolean clip;
 	private Number colorIndex;
+	private String colorKey;
 	private ArrayList<Color> colors;
+	private Boolean crisp;
 	private Cursor cursor;
 	private DataLabels dataLabels;
 	private Number depth;
@@ -53,6 +55,7 @@ public class PlotOptionsPie extends AbstractPlotOptions {
 	private ArrayList<String> keys;
 	private String linkedTo;
 	private Number minSize;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Boolean selected;
 	private Boolean shadow;
@@ -217,6 +220,24 @@ public class PlotOptionsPie extends AbstractPlotOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set
+	 * <p>
+	 * Defaults to <code>false</code>.
+	 * @param clip
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColorIndex(Number)
 	 */
 	public Number getColorIndex() {
@@ -232,6 +253,27 @@ public class PlotOptionsPie extends AbstractPlotOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point
+	 * color if <code>colorAxis</code> is used.
+	 * Requires to set min and max if some custom point property is used or if approximation
+	 * for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>y</code>.
+	 *
+	 * @param colorKey
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
 	}
 
 	/**
@@ -277,6 +319,27 @@ public class PlotOptionsPie extends AbstractPlotOptions {
 	 */
 	public void removeColor(Color color) {
 		this.colors.remove(color);
+	}
+
+	/**
+	 * @see #setCrisp(Boolean)
+	 */
+	public Boolean getCrisp() {
+		return crisp;
+	}
+
+	/**
+	 * When true, each point or column edge is rounded to its nearest pixel
+	 * in order to render sharp on screen. In some cases, when there are a lot of
+	 * densely packed columns, this leads to visible difference in column widths
+	 * or distance between columns. In these cases, setting <code>crisp</code>
+	 * to <code>false</code> may look better, even though each column
+	 * is rendered blurry.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setCrisp(Boolean crisp) {
+		this.crisp = crisp;
 	}
 
 	/**
@@ -578,6 +641,22 @@ public class PlotOptionsPie extends AbstractPlotOptions {
 	 */
 	public void setMinSize(Number minSize) {
 		this.minSize = minSize;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsPolygon.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsPolygon.java
@@ -17,13 +17,13 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.time.Instant;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
 /**
@@ -39,8 +39,11 @@ public class PlotOptionsPolygon extends AbstractPlotOptions {
 	private Boolean animation;
 	private Number animationLimit;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Number colorIndex;
+	private String colorKey;
+	private Boolean crisp;
 	private Number cropThreshold;
 	private Cursor cursor;
 	private DashStyle dashStyle;
@@ -54,6 +57,7 @@ public class PlotOptionsPolygon extends AbstractPlotOptions {
 	private String linkedTo;
 	private Marker marker;
 	private Color negativeColor;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -156,6 +160,23 @@ public class PlotOptionsPolygon extends AbstractPlotOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -202,6 +223,46 @@ public class PlotOptionsPolygon extends AbstractPlotOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color
+	 * if <code>colorAxis</code> is used. Requires to set <code>min</code> and
+	 * <code>max</code> if some custom point property is used
+	 * or if approximation for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>y</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
+	}
+
+	/**
+	 * @see #setCrisp(Boolean)
+	 */
+	public Boolean getCrisp() {
+		return crisp;
+	}
+
+	/**
+	 * When true, each point or column edge is rounded to its nearest pixel
+	 * in order to render sharp on screen. In some cases, when there are a lot of
+	 * densely packed columns, this leads to visible difference in column widths
+	 * or distance between columns. In these cases, setting <code>crisp</code> to
+	 * <code>false</code> may look better, even though each column is rendered
+	 * blurry.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setCrisp(Boolean crisp) {
+		this.crisp = crisp;
 	}
 
 	/**
@@ -507,6 +568,22 @@ public class PlotOptionsPolygon extends AbstractPlotOptions {
 	 */
 	public void setNegativeColor(Color negativeColor) {
 		this.negativeColor = negativeColor;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsPyramid.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsPyramid.java
@@ -17,11 +17,11 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
  * A pyramid chart consists of a single pyramid with item heights corresponding
@@ -37,8 +37,11 @@ public class PlotOptionsPyramid extends PyramidOptions {
 	private Number borderWidth;
 	private String[] center;
 	private String className;
+	private Boolean clip;
 	private Number colorIndex;
+	private String colorKey;
 	private ArrayList<Color> colors;
+	private Boolean crisp;
 	private Cursor cursor;
 	private DataLabelsFunnel dataLabels;
 	private Number depth;
@@ -48,9 +51,11 @@ public class PlotOptionsPyramid extends PyramidOptions {
 	private Dimension findNearestPointBy;
 	private Boolean getExtremesFromAll;
 	private String height;
+	private Boolean ignoreHiddenPoint;
 	private ArrayList<String> keys;
 	private String linkedTo;
 	private Number minSize;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Boolean reversed;
 	private Boolean selected;
@@ -194,6 +199,23 @@ public class PlotOptionsPyramid extends PyramidOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set.
+	 * <p>
+	 * Defaults to <code>false</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColorIndex(Number)
 	 */
 	public Number getColorIndex() {
@@ -209,6 +231,25 @@ public class PlotOptionsPyramid extends PyramidOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color
+	 * if <code>colorAxis</code> is used. Requires to set <code>min</code> and
+	 * <code>max</code> if some custom point property is used or if approximation
+	 * for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>y</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
 	}
 
 	/**
@@ -254,6 +295,27 @@ public class PlotOptionsPyramid extends PyramidOptions {
 	 */
 	public void removeColor(Color color) {
 		this.colors.remove(color);
+	}
+
+	/**
+	 * @see #setCrisp(Boolean)
+	 */
+	public Boolean getCrisp() {
+		return crisp;
+	}
+
+	/**
+	 * When true, each point or column edge is rounded to its nearest pixel
+	 * in order to render sharp on screen. In some cases, when there are a lot of
+	 * densely packed columns, this leads to visible difference in column widths
+	 * or distance between columns. In these cases, setting <code>crisp</code>
+	 * to <code>false</code> may look better, even though each column
+	 * is rendered blurry.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setCrisp(Boolean crisp) {
+		this.crisp = crisp;
 	}
 
 	/**
@@ -426,6 +488,23 @@ public class PlotOptionsPyramid extends PyramidOptions {
 	}
 
 	/**
+	 * @see #setIgnoreHiddenPoint(Boolean)
+	 */
+	public Boolean getIgnoreHiddenPoint() {
+		return ignoreHiddenPoint;
+	}
+
+	/**
+	 * This option tells whether the series shall be redrawn as if
+	 * the hidden point were null.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setIgnoreHiddenPoint(Boolean ignoreHiddenPoint) {
+		this.ignoreHiddenPoint = ignoreHiddenPoint;
+	}
+
+	/**
 	 * @see #setKeys(String...)
 	 */
 	public String[] getKeys() {
@@ -504,6 +583,22 @@ public class PlotOptionsPyramid extends PyramidOptions {
 	 */
 	public void setMinSize(Number minSize) {
 		this.minSize = minSize;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsScatter.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsScatter.java
@@ -17,13 +17,13 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.time.Instant;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
 @Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
@@ -33,8 +33,11 @@ public class PlotOptionsScatter extends PointOptions {
 	private Boolean animation;
 	private Number animationLimit;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Number colorIndex;
+	private String colorKey;
+	private Boolean crisp;
 	private Number cropThreshold;
 	private Cursor cursor;
 	private DashStyle dashStyle;
@@ -49,6 +52,7 @@ public class PlotOptionsScatter extends PointOptions {
 	private String linkedTo;
 	private Marker marker;
 	private Color negativeColor;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -153,6 +157,24 @@ public class PlotOptionsScatter extends PointOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that lipping should be always enabled when chart.zoomType is set
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -199,6 +221,48 @@ public class PlotOptionsScatter extends PointOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point
+	 * color if <code>colorAxis</code> is used.
+	 * Requires to set min and max if some custom point property is used or if approximation
+	 * for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>y</code>.
+	 *
+	 * @param colorKey
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
+	}
+
+	/**
+	 * @see #setCrisp(Boolean)
+	 */
+	public Boolean getCrisp() {
+		return crisp;
+	}
+
+	/**
+	 * When true, each point or column edge is rounded to its nearest pixel
+	 * in order to render sharp on screen. In some cases,
+	 * when there are a lot of densely packed columns, this leads to visible
+	 * difference in column widths or distance between columns. In these cases,
+	 * setting <code>crisp</code> to <code>false</code> may look better,
+	 * even though each column is rendered blurry.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setCrisp(Boolean crisp) {
+		this.crisp = crisp;
 	}
 
 	/**
@@ -533,6 +597,21 @@ public class PlotOptionsScatter extends PointOptions {
 	 */
 	public void setNegativeColor(Color negativeColor) {
 		this.negativeColor = negativeColor;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSeries.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSeries.java
@@ -17,13 +17,13 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.time.Instant;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
 /**
@@ -38,10 +38,13 @@ public class PlotOptionsSeries extends AbstractPlotOptions {
 	private Boolean animation;
 	private Number animationLimit;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Number colorIndex;
+	private String colorKey;
 	private Boolean connectEnds;
 	private Boolean connectNulls;
+	private Boolean crisp;
 	private Number cropThreshold;
 	private Cursor cursor;
 	private DashStyle dashStyle;
@@ -57,6 +60,7 @@ public class PlotOptionsSeries extends AbstractPlotOptions {
 	private String linkedTo;
 	private Marker marker;
 	private Color negativeColor;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -158,6 +162,23 @@ public class PlotOptionsSeries extends AbstractPlotOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -207,6 +228,27 @@ public class PlotOptionsSeries extends AbstractPlotOptions {
 	}
 
 	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point
+	 * color if <code>colorAxis</code> is used.
+	 * Requires to set min and max if some custom point property is used or if approximation
+	 * for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>y</code>.
+	 *
+	 * @param colorKey
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
+	}
+
+	/**
 	 * @see #setConnectEnds(Boolean)
 	 */
 	public Boolean getConnectEnds() {
@@ -237,6 +279,27 @@ public class PlotOptionsSeries extends AbstractPlotOptions {
 	 */
 	public void setConnectNulls(Boolean connectNulls) {
 		this.connectNulls = connectNulls;
+	}
+
+	/**
+	 * @see #setCrisp(Boolean)
+	 */
+	public Boolean getCrisp() {
+		return crisp;
+	}
+
+	/**
+	 * When true, each point or column edge is rounded to its nearest pixel
+	 * in order to render sharp on screen. In some cases, when there are a lot of
+	 * densely packed columns, this leads to visible difference in column widths
+	 * or distance between columns. In these cases, setting <code>crisp</code>
+	 * to <code>false</code> may look better, even though each column
+	 * is rendered blurry.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setCrisp(Boolean crisp) {
+		this.crisp = crisp;
 	}
 
 	/**
@@ -587,6 +650,22 @@ public class PlotOptionsSeries extends AbstractPlotOptions {
 	 */
 	public void setNegativeColor(Color negativeColor) {
 		this.negativeColor = negativeColor;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSolidgauge.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSolidgauge.java
@@ -35,7 +35,10 @@ public class PlotOptionsSolidgauge extends GaugeOptions {
 	private Boolean animation;
 	private Number animationLimit;
 	private String className;
+	private Boolean clip;
+	private Boolean colorByPoint;
 	private Number colorIndex;
+	private Boolean crisp;
 	private Cursor cursor;
 	private DataLabels dataLabels;
 	private String description;
@@ -46,6 +49,7 @@ public class PlotOptionsSolidgauge extends GaugeOptions {
 	private ArrayList<String> keys;
 	private String linecap;
 	private Number overshoot;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Boolean rounded;
 	private Boolean selected;
@@ -116,6 +120,39 @@ public class PlotOptionsSolidgauge extends GaugeOptions {
 	}
 
 	/**
+   * @see #setClip(Boolean)
+   */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
+	 * @see #setColorByPoint(Boolean)
+	 */
+	public Boolean getColorByPoint() {
+		return colorByPoint;
+	}
+
+	/**
+	 * Whether to give each point an individual color.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setColorByPoint(Boolean colorByPoint) {
+		this.colorByPoint = colorByPoint;
+	}
+
+	/**
 	 * @see #setColorIndex(Number)
 	 */
 	public Number getColorIndex() {
@@ -131,6 +168,27 @@ public class PlotOptionsSolidgauge extends GaugeOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setCrisp(Boolean)
+	 */
+	public Boolean getCrisp() {
+		return crisp;
+	}
+
+	/**
+	 * When true, each point or column edge is rounded to its nearest pixel
+	 * in order to render sharp on screen. In some cases, when there are a lot of
+	 * densely packed columns, this leads to visible difference in column widths
+	 * or distance between columns. In these cases, setting <code>crisp</code>
+	 * to <code>false</code> may look better, even though each column is
+	 * rendered blurry.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setCrisp(Boolean crisp) {
+		this.crisp = crisp;
 	}
 
 	/**
@@ -318,6 +376,22 @@ public class PlotOptionsSolidgauge extends GaugeOptions {
 	 */
 	public void removeKey(String key) {
 		this.keys.remove(key);
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	/**

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSpline.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSpline.java
@@ -17,13 +17,13 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.time.Instant;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
 @Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
@@ -33,10 +33,13 @@ public class PlotOptionsSpline extends PointOptions {
 	private Boolean animation;
 	private Number animationLimit;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Number colorIndex;
+	private String colorKey;
 	private Boolean connectEnds;
 	private Boolean connectNulls;
+	private Boolean crisp;
 	private Number cropThreshold;
 	private Cursor cursor;
 	private DashStyle dashStyle;
@@ -52,6 +55,7 @@ public class PlotOptionsSpline extends PointOptions {
 	private String linkedTo;
 	private Marker marker;
 	private Color negativeColor;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -157,6 +161,23 @@ public class PlotOptionsSpline extends PointOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that lipping should be always enabled when chart.zoomType is set
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setColor(Color)
 	 */
 	public Color getColor() {
@@ -203,6 +224,46 @@ public class PlotOptionsSpline extends PointOptions {
 	 */
 	public void setColorIndex(Number colorIndex) {
 		this.colorIndex = colorIndex;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point
+	 * color if <code>colorAxis</code> is used.
+	 * Requires to set min and max if some custom point property is used or if approximation
+	 * for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>y</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
+	}
+
+	/**
+	 * @see #setCrisp(Boolean)
+	 */
+	public Boolean getCrisp() {
+		return crisp;
+	}
+
+	/**
+	 * When true, each point or column edge is rounded to its nearest pixel
+	 * in order to render sharp on screen. In some cases,
+	 * when there are a lot of densely packed columns, this leads to visible
+	 * difference in column widths or distance between columns. In these cases,
+	 * setting <code>crisp</code> to <code>false</code> may look better,
+	 * even though each column is rendered blurry.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setCrisp(Boolean crisp) {
+		this.crisp = crisp;
 	}
 
 	/**
@@ -586,6 +647,22 @@ public class PlotOptionsSpline extends PointOptions {
 	 */
 	public void setNegativeColor(Color negativeColor) {
 		this.negativeColor = negativeColor;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsTimeline.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsTimeline.java
@@ -13,17 +13,24 @@ public class PlotOptionsTimeline extends AbstractPlotOptions {
     private Boolean allowPointSelect;
     private Boolean animation;
     private String className;
+    private Boolean clip;
     private Color color;
+    private Boolean colorByPoint;
     private Number colorIndex;
     private Cursor cursor;
+    private Boolean crisp;
     private DataLabels dataLabels;
     private String description;
     private Boolean enableMouseTracking;
     private Boolean exposeElementToA11y;
+    private Boolean ignoreHiddenPoint;
+    private Boolean includeInDataExport;
     private ArrayList<String> keys;
+    private String legendType;
     private String linecap;
     private String linkedTo;
     private Marker marker;
+    private Number opacity;
     private String _fn_pointDescriptionFormatter;
     private Boolean selected;
     private Boolean shadow;
@@ -98,6 +105,23 @@ public class PlotOptionsTimeline extends AbstractPlotOptions {
     }
 
     /**
+     * @see #setClip(Boolean)
+     */
+    public Boolean getClip() {
+        return clip;
+    }
+
+    /**
+     * Disable this option to allow series rendering in the whole plotting area.
+     * Note: Clipping should be always enabled when chart.zoomType is set
+     * <p>
+     * Defaults to <code>true</code>.
+     */
+    public void setClip(Boolean clip) {
+        this.clip = clip;
+    }
+
+    /**
      * @see #setColor(Color)
      */
     public Color getColor() {
@@ -127,6 +151,20 @@ public class PlotOptionsTimeline extends AbstractPlotOptions {
     public void setColor(Color color) {
         this.color = color;
     }
+
+    /**
+     * @see #setColorByPoint(Boolean)
+     */
+    public Boolean getColorByPoint() {
+        return colorByPoint;
+    }
+    /**
+     * Defaults to <code>true</code>
+     */
+    public void setColorByPoint(Boolean colorByPoint) {
+        this.colorByPoint = colorByPoint;
+    }
+
 
     /**
      * @see #setColorIndex(Number)
@@ -160,6 +198,27 @@ public class PlotOptionsTimeline extends AbstractPlotOptions {
      */
     public void setCursor(Cursor cursor) {
         this.cursor = cursor;
+    }
+
+    /**
+     * @see #setCrisp(Boolean)
+     */
+    public Boolean getCrisp() {
+        return crisp;
+    }
+
+    /**
+     * When true, each point or column edge is rounded to its nearest pixel
+     * in order to render sharp on screen.
+     * In some cases, when there are a lot of densely packed columns,
+     * this leads to visible difference in column widths or distance between columns.
+     * In these cases, setting crisp to false may look better,
+     * even though each column is rendered blurry.
+     *<p>
+     * Defaults to <code>true</code>.
+     */
+    public void setCrisp(Boolean crisp) {
+        this.crisp = crisp;
     }
 
     /**
@@ -257,6 +316,35 @@ public class PlotOptionsTimeline extends AbstractPlotOptions {
     }
 
     /**
+     * @see #setIgnoreHiddenPoint(Boolean)
+     */
+    public Boolean getIgnoreHiddenPoint() {
+        return ignoreHiddenPoint;
+    }
+
+    /**
+     * Defaults to <code>true</code>
+     */
+    public void setIgnoreHiddenPoint(Boolean ignoreHiddenPoint) {
+        this.ignoreHiddenPoint = ignoreHiddenPoint;
+    }
+
+    /**
+     * @see #setIgnoreHiddenPoint(Boolean)
+     */
+    public Boolean getIncludeInDataExport() {
+        return includeInDataExport;
+    }
+
+    /**
+     * When set to false will prevent the series data from being included in any form of data export.
+     * Defaults to <code>undefined</code>.
+     */
+    public void setIncludeInDataExport(Boolean includeInDataExport) {
+        this.includeInDataExport = includeInDataExport;
+    }
+
+    /**
      * @see #setKeys(String...)
      */
     public String[] getKeys() {
@@ -300,6 +388,20 @@ public class PlotOptionsTimeline extends AbstractPlotOptions {
      */
     public void removeKey(String key) {
         this.keys.remove(key);
+    }
+
+    /**
+     * @see #setLegendType(String)
+     */
+    public String getLegendType() {
+        return legendType;
+    }
+
+    /**
+     * Defaults to <code>point</>.
+     */
+    public void setLegendType(String legendType) {
+        this.legendType = legendType;
     }
 
     /**
@@ -364,6 +466,22 @@ public class PlotOptionsTimeline extends AbstractPlotOptions {
      */
     public void setMarker(Marker marker) {
         this.marker = marker;
+    }
+
+    /**
+     * @see #setOpacity(Number)
+     */
+    public Number getOpacity() {
+        return opacity;
+    }
+
+    /**
+     * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+     * <p>
+     * Defaults to <code>1</code>.
+     */
+    public void setOpacity(Number opacity) {
+        this.opacity = opacity;
     }
 
     public String getPointDescriptionFormatter() {

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsTimeline.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsTimeline.java
@@ -24,7 +24,6 @@ public class PlotOptionsTimeline extends AbstractPlotOptions {
     private Boolean enableMouseTracking;
     private Boolean exposeElementToA11y;
     private Boolean ignoreHiddenPoint;
-    private Boolean includeInDataExport;
     private ArrayList<String> keys;
     private String legendType;
     private String linecap;
@@ -327,21 +326,6 @@ public class PlotOptionsTimeline extends AbstractPlotOptions {
      */
     public void setIgnoreHiddenPoint(Boolean ignoreHiddenPoint) {
         this.ignoreHiddenPoint = ignoreHiddenPoint;
-    }
-
-    /**
-     * @see #setIgnoreHiddenPoint(Boolean)
-     */
-    public Boolean getIncludeInDataExport() {
-        return includeInDataExport;
-    }
-
-    /**
-     * When set to false will prevent the series data from being included in any form of data export.
-     * Defaults to <code>undefined</code>.
-     */
-    public void setIncludeInDataExport(Boolean includeInDataExport) {
-        this.includeInDataExport = includeInDataExport;
     }
 
     /**

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsWaterfall.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsWaterfall.java
@@ -17,13 +17,13 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
 import javax.annotation.Generated;
-import com.vaadin.flow.component.charts.model.style.Color;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.time.Instant;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
 /**
@@ -39,9 +39,11 @@ public class PlotOptionsWaterfall extends ColumnOptions {
 	private Number borderRadius;
 	private Number borderWidth;
 	private String className;
+	private Boolean clip;
 	private Color color;
 	private Boolean colorByPoint;
 	private Number colorIndex;
+	private String colorKey;
 	private ArrayList<Color> colors;
 	private Boolean crisp;
 	private Cursor cursor;
@@ -64,6 +66,7 @@ public class PlotOptionsWaterfall extends ColumnOptions {
 	private String linkedTo;
 	private Number maxPointWidth;
 	private Number minPointLength;
+	private Number opacity;
 	private String _fn_pointDescriptionFormatter;
 	private Number pointInterval;
 	private IntervalUnit pointIntervalUnit;
@@ -214,6 +217,23 @@ public class PlotOptionsWaterfall extends ColumnOptions {
 	}
 
 	/**
+	 * @see #setClip(Boolean)
+	 */
+	public Boolean getClip() {
+		return clip;
+	}
+
+	/**
+	 * Disable this option to allow series rendering in the whole plotting area.
+	 * Note that clipping should be always enabled when chart.zoomType is set.
+	 * <p>
+	 * Defaults to <code>true</code>.
+	 */
+	public void setClip(Boolean clip) {
+		this.clip = clip;
+	}
+
+	/**
 	 * @see #setClassName(String)
 	 */
 	public String getClassName() {
@@ -274,6 +294,25 @@ public class PlotOptionsWaterfall extends ColumnOptions {
 	 */
 	public void setColorByPoint(Boolean colorByPoint) {
 		this.colorByPoint = colorByPoint;
+	}
+
+	/**
+	 * @see #setColorKey(String)
+	 */
+	public String getColorKey() {
+		return colorKey;
+	}
+
+	/**
+	 * Determines what data value should be used to calculate point color if <code>colorAxis</code> is used.
+	 * Requires to set <code>min</code> and <code>amx</code> if some custom point property is used
+	 * or if approximation for data grouping is set to <code>'sum'</code>.
+	 * <p>
+	 * Defaults to <code>y</code>.
+	 */
+	public void setColorKey(String colorKey) {
+		this.colorKey = colorKey;
+
 	}
 
 	/**
@@ -754,6 +793,22 @@ public class PlotOptionsWaterfall extends ColumnOptions {
 	 */
 	public void setLinkedTo(String linkedTo) {
 		this.linkedTo = linkedTo;
+	}
+
+	/**
+	 * @see #setOpacity(Number)
+	 */
+	public Number getOpacity() {
+		return opacity;
+	}
+
+	/**
+	 * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+	 * <p>
+	 * Defaults to <code>1</code>.
+	 */
+	public void setOpacity(Number opacity) {
+		this.opacity = opacity;
 	}
 
 	/**

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PointOptions.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PointOptions.java
@@ -17,11 +17,10 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-
-import com.vaadin.flow.component.charts.model.style.Color;
-
 import java.time.Instant;
 import java.util.Date;
+
+import com.vaadin.flow.component.charts.model.style.Color;
 
 public abstract class PointOptions extends AbstractPlotOptions {
 
@@ -94,6 +93,17 @@ public abstract class PointOptions extends AbstractPlotOptions {
     public abstract void setClassName(String className);
 
     /**
+     * @see #setClip(Boolean)
+     */
+    public abstract Boolean getClip();
+
+    /**
+     * Disable this option to allow series rendering in the whole plotting area.
+     * Note that clipping should be always enabled when chart.zoomType is set
+     */
+    public abstract void setClip(Boolean clip);
+
+    /**
      * @see #setColorIndex(Number)
      */
     public abstract Number getColorIndex();
@@ -104,6 +114,32 @@ public abstract class PointOptions extends AbstractPlotOptions {
      * <code>highcharts-color-{n}</code>.
      */
     public abstract void setColorIndex(Number colorIndex);
+
+    public abstract String getColorKey();
+
+    /**
+     * Determines what data value should be used to calculate point color
+     * if <code>colorAxis</code> is used. Requires to set <code>min</code>
+     * and <code>max</code> if some custom point property is used
+     * or if approximation for data grouping is set to <code>'sum'</code>.
+     */
+    public abstract void setColorKey(String colorKey);
+
+    /**
+     * @see #setCrisp(Boolean)
+     */
+    public abstract Boolean getCrisp();
+
+    /**
+     * When true, each point or column edge is rounded to its nearest pixel
+     * in order to render sharp on screen.
+     * In some cases, when there are a lot of densely packed columns,
+     * this leads to visible difference in column widths
+     * or distance between columns. In these cases, setting <code>crisp</code>
+     * to <code>false</code> may look better,
+     * even though each column is rendered blurry.
+     */
+    public abstract void setCrisp(Boolean crisp);
 
     /**
      * @see #setCropThreshold(Number)
@@ -313,6 +349,16 @@ public abstract class PointOptions extends AbstractPlotOptions {
      * threshold.
      */
     public abstract void setNegativeColor(Color negativeColor);
+
+    /**
+     * @see #setOpacity(Number)
+     */
+    public abstract Number getOpacity();
+
+    /**
+     * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+     */
+    public abstract void setOpacity(Number opacity);
 
     public abstract String getPointDescriptionFormatter();
 

--- a/addon/src/main/java/com/vaadin/flow/component/charts/model/PyramidOptions.java
+++ b/addon/src/main/java/com/vaadin/flow/component/charts/model/PyramidOptions.java
@@ -66,6 +66,17 @@ public abstract class PyramidOptions extends AbstractPlotOptions {
     public abstract void setClassName(String className);
 
     /**
+     * @see #setClip(Boolean)
+     */
+    public abstract Boolean getClip();
+
+    /**
+     * Disable this option to allow series rendering in the whole plotting area.
+     * Note that clipping should be always enabled when chart.zoomType is set
+     */
+    public abstract void setClip(Boolean clip);
+
+    /**
      * @see #setColorIndex(Number)
      */
     public abstract Number getColorIndex();
@@ -76,6 +87,19 @@ public abstract class PyramidOptions extends AbstractPlotOptions {
      * <code>highcharts-color-{n}</code>.
      */
     public abstract void setColorIndex(Number colorIndex);
+
+    /**
+     * @see #setColorKey(String)
+     */
+    public abstract String getColorKey();
+
+    /**
+     * Determines what data value should be used to calculate point color if
+     * <code>colorAxis</code> is used. Requires to set <code>min</code>
+     * and <code>max</code> if some custom point property is used
+     * or if approximation for data grouping is set to <code>'sum'</code>.
+     */
+    public abstract void setColorKey(String colorKey);
 
     /**
      * @see #setColors(Color...)
@@ -105,6 +129,21 @@ public abstract class PyramidOptions extends AbstractPlotOptions {
      * @see #setColors(Color...)
      */
     public abstract void removeColor(Color color);
+
+    /**
+     * @see #setCrisp(Boolean)
+     */
+    public abstract Boolean getCrisp();
+
+    /**
+     * When true, each point or column edge is rounded to its nearest pixel
+     * in order to render sharp on screen. In some cases, when there are
+     * a lot of densely packed columns, this leads to visible difference
+     * in column widths or distance between columns.
+     * In these cases, setting crisp to <code>falase</code> may look better,
+     * even though each column is rendered blurry.
+     */
+    public abstract void setCrisp(Boolean crisp);
 
     /**
      * @see #setCursor(Cursor)
@@ -226,6 +265,17 @@ public abstract class PyramidOptions extends AbstractPlotOptions {
     public abstract void setHeight(String height);
 
     /**
+     * @see #setIgnoreHiddenPoint(Boolean)
+     */
+    public abstract Boolean getIgnoreHiddenPoint();
+
+    /**
+     * This option tells whether the series shall be redrawn
+     * as if the hidden point were null.
+     */
+    public abstract void setIgnoreHiddenPoint(Boolean ignoreHiddenPoint);
+
+    /**
      * @see #setKeys(String...)
      */
     public abstract String[] getKeys();
@@ -279,6 +329,16 @@ public abstract class PyramidOptions extends AbstractPlotOptions {
      * this size.
      */
     public abstract void setMinSize(Number minSize);
+
+    /**
+     * @see #setOpacity(Number)
+     */
+    public abstract Number getOpacity();
+
+    /**
+     * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+     */
+    public abstract void setOpacity(Number opacity);
 
     public abstract String getPointDescriptionFormatter();
 


### PR DESCRIPTION
PR add properties to the PlotOptions: 
- `PlotOptionsArea`
- `PlotOptionsArearange`
- `PlotOptionsAreaspline`
- `PlotOptionsAreaspline`
- `PlotOptionsTimeline`
 - `ColumnOptions` as a super class of :
    - `PlotOptionsBar`
    - `PlotOptionsColumn`
    - `PlotOptionsColumnrange`
    - `PlotOptionsWaterfall`
- `PlotOptionsBoxplot`
- `PlotOptionsBubble`
- `PlotOptionsErrorBar`
- `OhlcOptions` and its extending classes
    - `PlotOptionsCandlestick`
    - `PlotOptionsOhlc`
- `PointOptions` and its extending classes
    - `PlotOptionsLine`
    - `PlotOptionsScatter`
    - `PlotOptionsSpline`
- `GaugeOptions` and its extending classes
    - `PlotOptionsGauge`
    - `PlotOptionsSolidgauge`
- `PlotOptionsSeries`
- `PyramidOptions` and its extending classes
    - `PlotOptionsFunnel`
    - `PlotOptionsPyramid`
- `PlotOptionsPolygon`
- `PlotOptionsPie`
- `PlotOptionsHeatmap`
- `PlotOptionsFlags`

Webcomponent is missing `export-data.js` module, which is required for `includeInDataExport` to work. Therefore, no API is created for this property. As well the `custom` property mentioned in the ticket is skipped.

Fixes https://github.com/vaadin/vaadin-charts-flow/issues/366